### PR TITLE
fix: remove comments from manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Sora Prompt Builder",
   "short_name": "Sora",
-  "start_url": "/sora-prompt-builder/",   // ★絶対パスでリポ名を入れる
-  "scope": "/sora-prompt-builder/",       // ★ここも揃える
+  "start_url": "/sora-prompt-builder/",
+  "scope": "/sora-prompt-builder/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#111111",


### PR DESCRIPTION
## Summary
- remove inline comments from start_url and scope in manifest.json

## Testing
- `python -m json.tool manifest.json`
- `npm run build`
- `curl -s http://localhost:4174/sora-prompt-builder/assets/manifest-qf1jwTOd.json`

------
https://chatgpt.com/codex/tasks/task_e_68bc5c3388cc8322854864eaa2ef55cd