### PR TITLE
feat: add fashion dress options

### DIFF
--- a/src/data/options.js
+++ b/src/data/options.js
@@ -97,6 +97,13 @@ export const options = {
     { en: "slim fit trousers", jp: "スリムフィットパンツ" },
     { en: "leggings with long top", jp: "ロングトップス＋レギンス" },
   ],
+  fashionDresses: [
+    { en: "slip dress", jp: "スリップドレス" },
+    { en: "sundress", jp: "サマードレス" },
+    { en: "backless dress", jp: "背中の開いたドレス" },
+    { en: "sheer layered dress", jp: "透け感のあるレイヤードドレス" },
+    { en: "wrap dress", jp: "ラップドレス" },
+  ],
   outer: [
     { en: "", jp: "" },
     { en: "tailored blazer", jp: "テーラードブレザー" },


### PR DESCRIPTION
## Summary
- add `fashionDresses` options with five dress styles
- allow selecting a dress in the UI and prompt generation
- randomizer now can choose a dress instead of separate tops/bottoms

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc783480f08322abea7a800d4ad086