### PR TITLE
アニメ各項目の手入力欄を追加

### DIFF
--- a/src/AnimePromptBuilder.jsx
+++ b/src/AnimePromptBuilder.jsx
@@ -1,5 +1,13 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardHeader, CardContent, Button, Select, Textarea } from "./components/ui";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Button,
+  Select,
+  Textarea,
+  Input,
+} from "./components/ui";
 import { animeOptions, toSelectOptions, findJP } from "./data/animeOptions";
 import { Copy } from "lucide-react";
 
@@ -27,35 +35,70 @@ const defaultState = {
   mood: "romantic atmosphere",
   details: "sparkling eyes",
   style: "anime style",
+  characterTypeCustom: "",
+  hairColorCustom: "",
+  hairStyleCustom: "",
+  eyeColorCustom: "",
+  expressionCustom: "",
+  poseCustom: "",
+  fashionCustom: "",
+  backgroundCustom: "",
+  moodCustom: "",
+  detailsCustom: "",
+  styleCustom: "",
 };
 
 function buildEN(state) {
+  const characterType = state.characterTypeCustom || state.characterType;
+  const hairColor = state.hairColorCustom || state.hairColor;
+  const hairStyle = state.hairStyleCustom || state.hairStyle;
+  const eyeColor = state.eyeColorCustom || state.eyeColor;
+  const expression = state.expressionCustom || state.expression;
+  const pose = state.poseCustom || state.pose;
+  const fashion = state.fashionCustom || state.fashion;
+  const background = state.backgroundCustom || state.background;
+  const mood = state.moodCustom || state.mood;
+  const details = state.detailsCustom || state.details;
+  const style = state.styleCustom || state.style;
+
   const parts = [
-    `Detailed illustration of a ${state.characterType} with ${state.hairColor} ${state.hairStyle} hair and ${state.eyeColor} eyes`,
-    `${state.expression} expression`,
-    `${state.pose}`,
-    `wearing ${state.fashion}`,
-    `background: ${state.background}`,
-    `mood: ${state.mood}`,
-    `${state.details}`,
-    `style: ${state.style}`,
+    `Detailed illustration of a ${characterType} with ${hairColor} ${hairStyle} hair and ${eyeColor} eyes`,
+    `${expression} expression`,
+    `${pose}`,
+    `wearing ${fashion}`,
+    `background: ${background}`,
+    `mood: ${mood}`,
+    `${details}`,
+    `style: ${style}`,
   ];
   return parts.join(", ");
 }
 
 function buildJP(state) {
+  const characterType = state.characterTypeCustom || state.characterType;
+  const hairColor = state.hairColorCustom || state.hairColor;
+  const hairStyle = state.hairStyleCustom || state.hairStyle;
+  const eyeColor = state.eyeColorCustom || state.eyeColor;
+  const expression = state.expressionCustom || state.expression;
+  const pose = state.poseCustom || state.pose;
+  const fashion = state.fashionCustom || state.fashion;
+  const background = state.backgroundCustom || state.background;
+  const mood = state.moodCustom || state.mood;
+  const details = state.detailsCustom || state.details;
+  const style = state.styleCustom || state.style;
+
   const parts = [
     `美少女アニメのイラスト`,
-    `${findJP(state.characterType)}`,
-    `髪は${findJP(state.hairColor)}の${findJP(state.hairStyle)}`,
-    `瞳は${findJP(state.eyeColor)}`,
-    `${findJP(state.expression)}表情`,
-    `${findJP(state.pose)}`,
-    `${findJP(state.fashion)}`,
-    `背景:${findJP(state.background)}`,
-    `雰囲気:${findJP(state.mood)}`,
-    `${findJP(state.details)}`,
-    `スタイル:${findJP(state.style)}`,
+    `${findJP(characterType)}`,
+    `髪は${findJP(hairColor)}の${findJP(hairStyle)}`,
+    `瞳は${findJP(eyeColor)}`,
+    `${findJP(expression)}表情`,
+    `${findJP(pose)}`,
+    `${findJP(fashion)}`,
+    `背景:${findJP(background)}`,
+    `雰囲気:${findJP(mood)}`,
+    `${findJP(details)}`,
+    `スタイル:${findJP(style)}`,
   ];
   return parts.join("、");
 }
@@ -80,39 +123,79 @@ export default function AnimePromptBuilder() {
         <CardHeader title="Character" />
         <CardContent className="space-y-3">
           {field("Character Type", (
-            <Select
-              value={state.characterType}
-              onChange={(v) => setState({ ...state, characterType: v })}
-              options={toSelectOptions(animeOptions.characterType)}
-            />
+            <>
+              <Select
+                value={state.characterType}
+                onChange={(v) => setState({ ...state, characterType: v })}
+                options={toSelectOptions(animeOptions.characterType)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.characterTypeCustom}
+                onChange={(v) => setState({ ...state, characterTypeCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
           {field("Hair Color", (
-            <Select
-              value={state.hairColor}
-              onChange={(v) => setState({ ...state, hairColor: v })}
-              options={toSelectOptions(animeOptions.hairColor)}
-            />
+            <>
+              <Select
+                value={state.hairColor}
+                onChange={(v) => setState({ ...state, hairColor: v })}
+                options={toSelectOptions(animeOptions.hairColor)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.hairColorCustom}
+                onChange={(v) => setState({ ...state, hairColorCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
           {field("Hair Style", (
-            <Select
-              value={state.hairStyle}
-              onChange={(v) => setState({ ...state, hairStyle: v })}
-              options={toSelectOptions(animeOptions.hairStyle)}
-            />
+            <>
+              <Select
+                value={state.hairStyle}
+                onChange={(v) => setState({ ...state, hairStyle: v })}
+                options={toSelectOptions(animeOptions.hairStyle)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.hairStyleCustom}
+                onChange={(v) => setState({ ...state, hairStyleCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
           {field("Eye Color", (
-            <Select
-              value={state.eyeColor}
-              onChange={(v) => setState({ ...state, eyeColor: v })}
-              options={toSelectOptions(animeOptions.eyeColor)}
-            />
+            <>
+              <Select
+                value={state.eyeColor}
+                onChange={(v) => setState({ ...state, eyeColor: v })}
+                options={toSelectOptions(animeOptions.eyeColor)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.eyeColorCustom}
+                onChange={(v) => setState({ ...state, eyeColorCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
           {field("Expression", (
-            <Select
-              value={state.expression}
-              onChange={(v) => setState({ ...state, expression: v })}
-              options={toSelectOptions(animeOptions.expression)}
-            />
+            <>
+              <Select
+                value={state.expression}
+                onChange={(v) => setState({ ...state, expression: v })}
+                options={toSelectOptions(animeOptions.expression)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.expressionCustom}
+                onChange={(v) => setState({ ...state, expressionCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
         </CardContent>
       </Card>
@@ -121,46 +204,94 @@ export default function AnimePromptBuilder() {
         <CardHeader title="Scene" />
         <CardContent className="space-y-3">
           {field("Pose", (
-            <Select
-              value={state.pose}
-              onChange={(v) => setState({ ...state, pose: v })}
-              options={toSelectOptions(animeOptions.pose)}
-            />
+            <>
+              <Select
+                value={state.pose}
+                onChange={(v) => setState({ ...state, pose: v })}
+                options={toSelectOptions(animeOptions.pose)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.poseCustom}
+                onChange={(v) => setState({ ...state, poseCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
           {field("Fashion", (
-            <Select
-              value={state.fashion}
-              onChange={(v) => setState({ ...state, fashion: v })}
-              options={toSelectOptions(animeOptions.fashion)}
-            />
+            <>
+              <Select
+                value={state.fashion}
+                onChange={(v) => setState({ ...state, fashion: v })}
+                options={toSelectOptions(animeOptions.fashion)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.fashionCustom}
+                onChange={(v) => setState({ ...state, fashionCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
           {field("Background", (
-            <Select
-              value={state.background}
-              onChange={(v) => setState({ ...state, background: v })}
-              options={toSelectOptions(animeOptions.background)}
-            />
+            <>
+              <Select
+                value={state.background}
+                onChange={(v) => setState({ ...state, background: v })}
+                options={toSelectOptions(animeOptions.background)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.backgroundCustom}
+                onChange={(v) => setState({ ...state, backgroundCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
           {field("Mood", (
-            <Select
-              value={state.mood}
-              onChange={(v) => setState({ ...state, mood: v })}
-              options={toSelectOptions(animeOptions.mood)}
-            />
+            <>
+              <Select
+                value={state.mood}
+                onChange={(v) => setState({ ...state, mood: v })}
+                options={toSelectOptions(animeOptions.mood)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.moodCustom}
+                onChange={(v) => setState({ ...state, moodCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
           {field("Details", (
-            <Select
-              value={state.details}
-              onChange={(v) => setState({ ...state, details: v })}
-              options={toSelectOptions(animeOptions.details)}
-            />
+            <>
+              <Select
+                value={state.details}
+                onChange={(v) => setState({ ...state, details: v })}
+                options={toSelectOptions(animeOptions.details)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.detailsCustom}
+                onChange={(v) => setState({ ...state, detailsCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
           {field("Style", (
-            <Select
-              value={state.style}
-              onChange={(v) => setState({ ...state, style: v })}
-              options={toSelectOptions(animeOptions.style)}
-            />
+            <>
+              <Select
+                value={state.style}
+                onChange={(v) => setState({ ...state, style: v })}
+                options={toSelectOptions(animeOptions.style)}
+              />
+              <Input
+                placeholder="手入力"
+                value={state.styleCustom}
+                onChange={(v) => setState({ ...state, styleCustom: v })}
+                className="mt-1"
+              />
+            </>
           ))}
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Selectコンポーネントを通常のプルダウンに戻す
- 各アニメ項目に自由入力欄を追加し、手入力を優先してプロンプトを生成

## Testing
- `npm test` (スクリプト未定義)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bde1a2ce9c8322b8a2b62b02c90956