### PR TITLE
プルダウン選択の復元と手入力欄の追加

### DIFF
--- a/src/components/ui.jsx
+++ b/src/components/ui.jsx
@@ -51,29 +51,8 @@ export const Select = ({
   options,
   className = "",
   allowCustom = false,
-}) => {
-  if (allowCustom) {
-    const id = React.useId();
-    return (
-      <>
-        <input
-          list={id}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className={`w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm ${className}`}
-        />
-        <datalist id={id}>
-          {options.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </datalist>
-      </>
-    );
-  }
-
-  return (
+}) => (
+  <>
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
@@ -85,8 +64,15 @@ export const Select = ({
         </option>
       ))}
     </select>
-  );
-};
+    {allowCustom && (
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm mt-2 ${className}`}
+      />
+    )}
+  </>
+);
 
 export const Input = ({
   value,


### PR DESCRIPTION
## Summary
- allowCustomを用いたプルダウンを復元し、手入力欄を各項目に追加

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bde4442a588322a497be868d16bad3