### PR TITLE
アニメプロンプトビルダーでスクロール時もプロンプトを固定表示

### DIFF
--- a/src/AnimePromptBuilder.jsx
+++ b/src/AnimePromptBuilder.jsx
@@ -105,7 +105,7 @@ export default function AnimePromptBuilder() {
   );
 
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
+    <div className="max-w-3xl mx-auto space-y-6 pb-32">
       <div className="flex justify-end gap-2">
         <Button onClick={randomize} title="Randomize">
           <Shuffle className="h-4 w-4" />Random
@@ -230,7 +230,7 @@ export default function AnimePromptBuilder() {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card className="sticky bottom-0 bg-white z-10">
         <CardHeader title="Prompts" />
         <CardContent className="space-y-3">
           <div className="space-y-1">


### PR DESCRIPTION
## Summary
- スクロールしてもプロンプトカードが画面下部に固定されるように調整
- プロンプトカードが他の項目を隠さないよう余白を追加

## Testing
- `npm test` (Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdefcf55188322a97fb49aa11561a5