### PR TITLE
fix: keep prompt card pinned

### DIFF
--- a/src/SoraPromptBuilder.jsx
+++ b/src/SoraPromptBuilder.jsx
@@ -594,7 +594,7 @@ export default function SoraPromptBuilder() {
 
         {/* RIGHT: Outputs */}
         <div className="space-y-6">
-          <Card className="sticky bottom-0 bg-white z-10">
+          <Card className="fixed bottom-0 left-0 right-0 bg-white z-10">
             <CardHeader
               title={lang === "EN" ? "English Prompt" : "日本語プロンプト"}
               subtitle={


### PR DESCRIPTION
## Summary
- keep prompt card fixed to viewport bottom so it stays visible while scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be059117c48322ac6d1af04a77d7e6