### PR TITLE
プロンプト表示を切り替えるボタンを追加

### DIFF
--- a/src/AnimePromptBuilder.jsx
+++ b/src/AnimePromptBuilder.jsx
@@ -71,6 +71,7 @@ export default function AnimePromptBuilder() {
   const { copy } = useClipboard();
 
   const [lang, setLang] = useState("EN");
+  const [showPrompt, setShowPrompt] = useState(false);
 
   const EN = useMemo(() => buildEN(state), [state]);
   const JP = useMemo(() => buildJP(state), [state]);
@@ -232,43 +233,51 @@ export default function AnimePromptBuilder() {
         </CardContent>
       </Card>
 
-      <Card className="sticky bottom-0 bg-white z-10">
-        <CardHeader
-          title="Prompt"
-          right={
-            <div className="flex gap-2">
+      {showPrompt && (
+        <Card className="fixed bottom-16 left-0 right-0 bg-white z-10 max-w-3xl mx-auto">
+          <CardHeader
+            title="Prompt"
+            right={
+              <div className="flex gap-2">
+                <Button
+                  variant={lang === "EN" ? "default" : "subtle"}
+                  onClick={() => setLang("EN")}
+                >
+                  EN
+                </Button>
+                <Button
+                  variant={lang === "JP" ? "default" : "subtle"}
+                  onClick={() => setLang("JP")}
+                >
+                  JP
+                </Button>
+              </div>
+            }
+          />
+          <CardContent className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-gray-600">
+                {lang === "EN" ? "English" : "日本語"}
+              </label>
+              <Textarea value={lang === "EN" ? EN : JP} readOnly />
               <Button
-                variant={lang === "EN" ? "default" : "subtle"}
-                onClick={() => setLang("EN")}
+                onClick={() => copy(lang === "EN" ? EN : JP)}
+                className="mt-1"
+                title={lang === "EN" ? "Copy English" : "Copy Japanese"}
               >
-                EN
-              </Button>
-              <Button
-                variant={lang === "JP" ? "default" : "subtle"}
-                onClick={() => setLang("JP")}
-              >
-                JP
+                <Copy className="h-4 w-4" />
+                {lang === "EN" ? "Copy EN" : "コピー"}
               </Button>
             </div>
-          }
-        />
-        <CardContent className="space-y-3">
-          <div className="space-y-1">
-            <label className="text-xs font-medium text-gray-600">
-              {lang === "EN" ? "English" : "日本語"}
-            </label>
-            <Textarea value={lang === "EN" ? EN : JP} readOnly />
-            <Button
-              onClick={() => copy(lang === "EN" ? EN : JP)}
-              className="mt-1"
-              title={lang === "EN" ? "Copy English" : "Copy Japanese"}
-            >
-              <Copy className="h-4 w-4" />
-              {lang === "EN" ? "Copy EN" : "コピー"}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      )}
+      <Button
+        className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-20"
+        onClick={() => setShowPrompt((p) => !p)}
+      >
+        {showPrompt ? "Hide Prompt" : "Show Prompt"}
+      </Button>
     </div>
   );
 }

--- a/src/SoraPromptBuilder.jsx
+++ b/src/SoraPromptBuilder.jsx
@@ -261,6 +261,7 @@ export default function SoraPromptBuilder() {
   const [seed, setSeed] = useState(0);
   const { copy } = useClipboard();
   const [lang, setLang] = useState("EN");
+  const [showPrompt, setShowPrompt] = useState(false);
 
   const EN = useMemo(() => buildEnglishPrompt(state), [state]);
   const JP = useMemo(() => buildJapanesePrompt(state), [state]);
@@ -594,58 +595,67 @@ export default function SoraPromptBuilder() {
 
         {/* RIGHT: Outputs */}
         <div className="space-y-6">
-          <Card className="fixed bottom-0 left-0 right-0 bg-white z-10">
-            <CardHeader
-              title={lang === "EN" ? "English Prompt" : "日本語プロンプト"}
-              subtitle={
-                lang === "EN"
-                  ? "Natural prose for Sora - copy-ready."
-                  : "英語と別でコピペしやすいよう分離。辞書ベースでオフライン生成。"
-              }
-              right={
-                <div className="flex gap-2">
-                  <Button
-                    variant={lang === "EN" ? "default" : "subtle"}
-                    onClick={() => setLang("EN")}
-                  >
-                    EN
-                  </Button>
-                  <Button
-                    variant={lang === "JP" ? "default" : "subtle"}
-                    onClick={() => setLang("JP")}
-                  >
-                    JP
-                  </Button>
-                </div>
-              }
-            />
-            <CardContent>
-              <div className="flex items-center justify-between mb-3">
-                {lang === "EN" ? (
-                  <div className="text-xs text-gray-500">
-                    Aperture ≈ {apertureFromDof(state.dofStrength)} (from DoF {state.dofStrength})
+          {showPrompt && (
+            <Card className="fixed bottom-16 left-0 right-0 bg-white z-10">
+              <CardHeader
+                title={lang === "EN" ? "English Prompt" : "日本語プロンプト"}
+                subtitle={
+                  lang === "EN"
+                    ? "Natural prose for Sora - copy-ready."
+                    : "英語と別でコピペしやすいよう分離。辞書ベースでオフライン生成。"
+                }
+                right={
+                  <div className="flex gap-2">
+                    <Button
+                      variant={lang === "EN" ? "default" : "subtle"}
+                      onClick={() => setLang("EN")}
+                    >
+                      EN
+                    </Button>
+                    <Button
+                      variant={lang === "JP" ? "default" : "subtle"}
+                      onClick={() => setLang("JP")}
+                    >
+                      JP
+                    </Button>
                   </div>
-                ) : (
-                  <div className="flex items-center gap-2 text-xs text-gray-500">
-                    <Languages className="h-4 w-4" />内蔵変換 (機械翻訳API不使用)
+                }
+              />
+              <CardContent>
+                <div className="flex items-center justify-between mb-3">
+                  {lang === "EN" ? (
+                    <div className="text-xs text-gray-500">
+                      Aperture ≈ {apertureFromDof(state.dofStrength)} (from DoF {state.dofStrength})
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-2 text-xs text-gray-500">
+                      <Languages className="h-4 w-4" />内蔵変換 (機械翻訳API不使用)
+                    </div>
+                  )}
+                  <div className="flex gap-2">
+                    <Button
+                      variant="ghost"
+                      onClick={() => copy(lang === "EN" ? EN : JP)}
+                      title={lang === "EN" ? "Copy English" : "Copy Japanese"}
+                    >
+                      <Copy className="h-4 w-4" />
+                      {lang === "EN" ? "Copy" : "コピー"}
+                    </Button>
                   </div>
-                )}
-                <div className="flex gap-2">
-                  <Button
-                    variant="ghost"
-                    onClick={() => copy(lang === "EN" ? EN : JP)}
-                    title={lang === "EN" ? "Copy English" : "Copy Japanese"}
-                  >
-                    <Copy className="h-4 w-4" />
-                    {lang === "EN" ? "Copy" : "コピー"}
-                  </Button>
                 </div>
-              </div>
-              <Textarea value={lang === "EN" ? EN : JP} onChange={() => {}} rows={14} className="font-mono" />
-            </CardContent>
-          </Card>
+                <Textarea value={lang === "EN" ? EN : JP} onChange={() => {}} rows={14} className="font-mono" />
+              </CardContent>
+            </Card>
+          )}
         </div>
       </main>
+
+      <Button
+        className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-20"
+        onClick={() => setShowPrompt((p) => !p)}
+      >
+        {showPrompt ? "Hide Prompt" : "Show Prompt"}
+      </Button>
 
       <footer className="max-w-6xl mx-auto px-4 pb-10 text-xs text-gray-500">
         <p>


### PR DESCRIPTION
## 概要
- プロンプトパネルをボタンで表示・非表示できるように変更
- プロンプト表示用のボタンを画面下部に常時配置

## テスト
- `npm test` (npm が存在しないため失敗)
- `apt-get update` (リポジトリへのアクセス権がなく失敗)


------
https://chatgpt.com/codex/tasks/task_e_68be09260430832287413ad7e7e989c5