### PR TITLE
Remove Japanese prompt from JSON export

### DIFF
--- a/src/SoraPromptBuilder.jsx
+++ b/src/SoraPromptBuilder.jsx
@@ -255,11 +255,10 @@ function buildJapanesePrompt(state) {
   );
 }
 
-function buildSoraJSON(state, EN, JP) {
+function buildSoraJSON(state, EN) {
   return {
     prompt: {
       en: EN,
-      jp: JP,
     },
     camera: {
       shot: pref(state.shot, state.shotManual),
@@ -288,7 +287,7 @@ export default function SoraPromptBuilder() {
   const JP = useMemo(() => buildJapanesePrompt(state), [state]);
 
   const exportJSON = () => {
-    const soraReady = buildSoraJSON(state, EN, JP);
+    const soraReady = buildSoraJSON(state, EN);
     const blob = new Blob([JSON.stringify(soraReady, null, 2)], {
       type: "application/json",
     });


### PR DESCRIPTION
## Summary
- only include English prompt in Sora prompt JSON export

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c424b76bc88322aaa9c3cad9b907ce