### PR TITLE
refactor: use top-level prompt string in JSON exports

### DIFF
--- a/src/AnimePromptBuilder.jsx
+++ b/src/AnimePromptBuilder.jsx
@@ -70,7 +70,7 @@ function buildJP(state) {
 }
 
 function buildAnimeJSON(state, EN) {
-  const prompt = {
+  const details = {
     character: {
       type: state.characterType,
       hair_color: state.hairColor,
@@ -93,11 +93,11 @@ function buildAnimeJSON(state, EN) {
     style: {
       visual_style: state.style,
     },
-    text: EN,
   };
 
   return {
-    prompt,
+    prompt: EN,
+    details,
     metadata: state,
   };
 }

--- a/src/SoraPromptBuilder.jsx
+++ b/src/SoraPromptBuilder.jsx
@@ -275,7 +275,7 @@ function buildSoraJSON(state, EN) {
   const outer = pref(state.outer, state.outerManual);
   const outfit = outer ? `${outfitBase}, with ${outer}` : outfitBase;
 
-  const prompt = {
+  const details = {
     character: {
       age: pref(state.age, state.ageManual),
       gender: pref(state.gender, state.genderManual),
@@ -310,11 +310,11 @@ function buildSoraJSON(state, EN) {
       mood: pref(state.mood, state.moodManual),
       visual_style: styleArr,
     },
-    text: EN,
   };
 
   return {
-    prompt,
+    prompt: EN,
+    details,
     metadata: state,
   };
 }


### PR DESCRIPTION
## Summary
- output English prompt text directly under top-level `prompt`
- move structured prompt components into a separate `details` object

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4328e97708322901412a75f3e30b8