### PR TITLE
Add 'None selected' options and example placeholders

### DIFF
--- a/src/SoraPromptBuilder.jsx
+++ b/src/SoraPromptBuilder.jsx
@@ -442,13 +442,26 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
 
   const multiPills = (values, setValues, pool) => (
     <div className="flex flex-wrap gap-2">
+      <button
+        key="__none"
+        onClick={() => setValues([])}
+        className={`px-2.5 py-1 rounded-full text-xs border ${
+          values.length === 0 ? "bg-black text-white border-black" : "bg-white text-gray-700 border-gray-300"
+        }`}
+      >
+        {uiLang === "JP" ? "何も選択していない" : "Nothing selected"}
+      </button>
       {pool.map((opt) => {
         const active = values.includes(opt.en);
         return (
           <button
             key={opt.en}
-            onClick={() => setValues(active ? values.filter((v) => v !== opt.en) : [...values, opt.en])}
-            className={`px-2.5 py-1 rounded-full text-xs border ${active ? "bg-black text-white border-black" : "bg-white text-gray-700 border-gray-300"}`}
+            onClick={() =>
+              setValues(active ? values.filter((v) => v !== opt.en) : [...values, opt.en])
+            }
+            className={`px-2.5 py-1 rounded-full text-xs border ${
+              active ? "bg-black text-white border-black" : "bg-white text-gray-700 border-gray-300"
+            }`}
           >
             {uiLang === "JP" ? opt.jp : opt.en}
           </button>

--- a/src/components/ui.jsx
+++ b/src/components/ui.jsx
@@ -68,6 +68,7 @@ export const Select = ({
       <input
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        placeholder="e.g."
         className={`w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm mt-2 ${className}`}
       />
     )}

--- a/src/data/animeOptions.js
+++ b/src/data/animeOptions.js
@@ -245,8 +245,13 @@ export const animeOptions = {
 // Same as in options.js but for anime-specific groups.
 // Labels switch between English and Japanese based on `lang` while values stay
 // in English to keep JSON output unaffected.
-export const toSelectOptions = (arr, lang = "EN") =>
-  arr.map((i) => ({ value: i.en, label: lang === "JP" ? i.jp : i.en }));
+export const toSelectOptions = (arr, lang = "EN") => {
+  const noneLabel = lang === "JP" ? "何も選択していない" : "Nothing selected";
+  const mapped = arr
+    .filter((i) => i.en)
+    .map((i) => ({ value: i.en, label: lang === "JP" ? i.jp : i.en }));
+  return [{ value: "", label: noneLabel }, ...mapped];
+};
 
 export function findJP(en) {
   for (const group of Object.values(animeOptions)) {

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -267,8 +267,13 @@ export const options = {
 // Convert option objects to Select component friendly format.
 // `lang` determines which label (English or Japanese) is shown while the value
 // remains in English so that exported JSON stays consistent.
-export const toSelectOptions = (arr, lang = "EN") =>
-  arr.map((i) => ({ value: i.en, label: lang === "JP" ? i.jp : i.en }));
+export const toSelectOptions = (arr, lang = "EN") => {
+  const noneLabel = lang === "JP" ? "何も選択していない" : "Nothing selected";
+  const mapped = arr
+    .filter((i) => i.en)
+    .map((i) => ({ value: i.en, label: lang === "JP" ? i.jp : i.en }));
+  return [{ value: "", label: noneLabel }, ...mapped];
+};
 
 export function findJP(en) {
   for (const group of Object.values(options)) {


### PR DESCRIPTION
## Summary
- allow all selects to choose "Nothing selected" with JP/EN labels
- show "e.g." placeholder for manual custom inputs
- add "Nothing selected" option to multi-select pills

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c6f2e75a308322904526cdad067b89