### PR TITLE
Unify empty selection handling and custom input placeholder

### DIFF
--- a/src/SoraPromptBuilder.jsx
+++ b/src/SoraPromptBuilder.jsx
@@ -448,9 +448,8 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
         className={`px-2.5 py-1 rounded-full text-xs border ${
           values.length === 0 ? "bg-black text-white border-black" : "bg-white text-gray-700 border-gray-300"
         }`}
-      >
-        {uiLang === "JP" ? "何も選択していない" : "Nothing selected"}
-      </button>
+        aria-label={uiLang === "JP" ? "何も選択していない" : "Nothing selected"}
+      ></button>
       {pool.map((opt) => {
         const active = values.includes(opt.en);
         return (
@@ -564,7 +563,7 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
                   <Select
                     value={state.dress}
                     onChange={(v) => setState({ ...state, dress: v })}
-                    options={[{ value: "", label: "" }, ...toSelectOptions(options.fashionDresses, uiLang)]}
+                    options={toSelectOptions(options.fashionDresses, uiLang)}
                   />
                   <Input
                     value={state.dressManual}

--- a/src/components/ui.jsx
+++ b/src/components/ui.jsx
@@ -51,6 +51,7 @@ export const Select = ({
   options,
   className = "",
   allowCustom = false,
+  customPlaceholder = "e.g.",
 }) => (
   <>
     <select
@@ -68,7 +69,7 @@ export const Select = ({
       <input
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="e.g."
+        placeholder={customPlaceholder}
         className={`w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm mt-2 ${className}`}
       />
     )}

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -268,11 +268,10 @@ export const options = {
 // `lang` determines which label (English or Japanese) is shown while the value
 // remains in English so that exported JSON stays consistent.
 export const toSelectOptions = (arr, lang = "EN") => {
-  const noneLabel = lang === "JP" ? "何も選択していない" : "Nothing selected";
   const mapped = arr
     .filter((i) => i.en)
     .map((i) => ({ value: i.en, label: lang === "JP" ? i.jp : i.en }));
-  return [{ value: "", label: noneLabel }, ...mapped];
+  return [{ value: "", label: "" }, ...mapped];
 };
 
 export function findJP(en) {


### PR DESCRIPTION
## Summary
- hide labels for unselected options to avoid lingering text
- add aria-label only clear button for multi-select pills
- expose customizable "e.g." placeholder for select inputs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6f5c001cc8322881af60a68546211