### PR TITLE
セレクト未選択時の表示調整とマルチピルのクリア改善

### DIFF
--- a/src/SoraPromptBuilder.jsx
+++ b/src/SoraPromptBuilder.jsx
@@ -445,11 +445,9 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
       <button
         key="__none"
         onClick={() => setValues([])}
-        className={`px-2.5 py-1 rounded-full text-xs border ${
-          values.length === 0 ? "bg-black text-white border-black" : "bg-white text-gray-700 border-gray-300"
-        }`}
-        aria-label={uiLang === "JP" ? "何も選択していない" : "Nothing selected"}
-      ></button>
+        className="sr-only"
+        aria-label={uiLang === "JP" ? "すべて解除" : "Clear all selections"}
+      />
       {pool.map((opt) => {
         const active = values.includes(opt.en);
         return (
@@ -494,7 +492,11 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
             <CardContent className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {field("Age", (
                 <div className="space-y-2">
-                  <Select value={state.age} onChange={(v) => setState({ ...state, age: v })} options={[{ value: "", label: "" }, ...toSelectOptions(options.age, uiLang)]} />
+                  <Select
+                    value={state.age}
+                    onChange={(v) => setState({ ...state, age: v })}
+                    options={toSelectOptions(options.age, uiLang)}
+                  />
                   <Input value={state.ageManual} onChange={(v) => setState({ ...state, ageManual: v })} placeholder="e.g. early 20s" />
                 </div>
               ))}

--- a/src/data/animeOptions.js
+++ b/src/data/animeOptions.js
@@ -246,11 +246,10 @@ export const animeOptions = {
 // Labels switch between English and Japanese based on `lang` while values stay
 // in English to keep JSON output unaffected.
 export const toSelectOptions = (arr, lang = "EN") => {
-  const noneLabel = lang === "JP" ? "何も選択していない" : "Nothing selected";
   const mapped = arr
     .filter((i) => i.en)
     .map((i) => ({ value: i.en, label: lang === "JP" ? i.jp : i.en }));
-  return [{ value: "", label: noneLabel }, ...mapped];
+  return [{ value: "", label: "" }, ...mapped];
 };
 
 export function findJP(en) {


### PR DESCRIPTION
## Summary
- セレクト項目の未選択ラベルを空文字に統一し、解除後に表示が残らないよう修正
- マルチ選択ピルのクリアボタンを非表示化し、aria-label でのみ説明
- セレクトの手入力欄でカスタムプレースホルダーを "e.g." として表示

## Testing
- `npm test` (missing script: test)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6f825c67c83228a3282008c788909