### PR TITLE
Enhance prompt builders with structured workflow and presets

### DIFF
--- a/src/AnimePromptBuilder.jsx
+++ b/src/AnimePromptBuilder.jsx
@@ -1,21 +1,37 @@
-import React, { useMemo, useState } from "react";
-import { Card, CardHeader, CardContent, Button, Select, Textarea } from "./components/ui";
+import React, { useMemo, useRef, useState } from "react";
+import {
+  Copy,
+  Shuffle,
+  RotateCcw,
+  Download,
+  Languages,
+  Wand2,
+  Layers,
+} from "lucide-react";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Button,
+  Select,
+  Textarea,
+  Input,
+  ActionBar,
+  FloatingToast,
+} from "./components/ui";
+import PresetManager from "./components/PresetManager.jsx";
 import { animeOptions, toSelectOptions, findJP } from "./data/animeOptions";
-import { Copy, Shuffle, RotateCcw, Wand2, Languages, Download } from "lucide-react";
+import { useCopyFeedback } from "./hooks/useCopyFeedback.js";
+import { listToOxford, normalizeEnglish, compactSegments } from "./utils/text.js";
 
-function useClipboard() {
-  const copy = async (text) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-  return { copy };
-}
+const mergeMulti = (list = [], extra) => {
+  const arr = Array.isArray(list) ? list.filter(Boolean) : [];
+  const extraStr = extra && String(extra).trim();
+  if (extraStr) arr.push(extraStr);
+  return arr.filter(Boolean);
+};
 
-const defaultState = {
+const defaultState = () => ({
   characterType: "cheerful and energetic girl",
   hairColor: "blonde",
   hairStyle: "long straight",
@@ -31,92 +47,119 @@ const defaultState = {
   shotAngle: "",
   shotStyle: "",
   style: "anime style",
+  cameraMovement: "static anime cut",
+  shutterSpeed: "1/60s (anime crisp)",
+  colorGrade: "neutral anime grade",
+  renderFinish: ["4K clean line art render"],
+  renderFinishExtra: "",
+  subjectConsistency: false,
+  extraEN: "",
+  extraJP: "",
+});
+
+const cloneState = (state) => JSON.parse(JSON.stringify(state));
+
+const buildEN = (state) => {
+  const renderFinish = mergeMulti(state.renderFinish, state.renderFinishExtra);
+  const subjectSegment = `Detailed illustration of a ${state.characterType} with ${state.hairColor} ${state.hairStyle} hair, ${state.eyeColor} eyes, ${state.expression} expression, posing as ${state.pose}, wearing ${state.fashion}.`;
+  const sceneSegment = `Set in ${state.background} with a ${state.mood} mood, within a ${state.genre} tone, featuring ${state.details}.`;
+  const cameraParts = compactSegments([
+    [state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean).join(", "),
+    state.cameraMovement,
+    `shutter ${state.shutterSpeed}`,
+  ]);
+  const cameraSegment = cameraParts.length ? `Camera: ${cameraParts.join(", ")}.` : "";
+  const styleSegment = `Visual style: ${state.style}. Color grade: ${state.colorGrade}.`;
+  const renderSegmentParts = compactSegments([
+    renderFinish.length ? `Render finish: ${listToOxford(renderFinish)}` : "",
+    state.subjectConsistency ? "Maintain subject continuity across frames" : "",
+    state.extraEN?.trim() ? `Notes: ${state.extraEN.trim()}` : "",
+  ]);
+  const renderSegment = renderSegmentParts.join(". ");
+
+  return normalizeEnglish(
+    compactSegments([subjectSegment, sceneSegment, cameraSegment, styleSegment, renderSegment]).join(" ")
+  );
 };
 
-function buildEN(state) {
-  const parts = [
-    `Detailed illustration of a ${state.characterType} with ${state.hairColor} ${state.hairStyle} hair and ${state.eyeColor} eyes`,
-    `${state.expression} expression`,
-    `${state.pose}`,
-    `wearing ${state.fashion}`,
-    `background: ${state.background}`,
-    `mood: ${state.mood}`,
-    `genre: ${state.genre}`,
-    `${state.details}`,
-    `camera: ${[state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean).join(", ")}`,
-    `style: ${state.style}`,
-  ];
-  return parts.join(", ");
-}
+const buildJP = (state) => {
+  const renderFinish = mergeMulti(state.renderFinish.map(findJP), state.renderFinishExtra);
+  const lines = compactSegments([
+    `${findJP(state.characterType)}。髪は${findJP(state.hairColor)}の${findJP(state.hairStyle)}、瞳は${findJP(state.eyeColor)}、表情は${findJP(state.expression)}。ポーズ：${findJP(state.pose)}。衣装：${findJP(state.fashion)}。`,
+    `背景：${findJP(state.background)}。ムード：${findJP(state.mood)}。ジャンル：${findJP(state.genre)}。ディテール：${findJP(state.details)}。`,
+    `カメラ：${[state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean).map(findJP).join("、")}、カメラワーク：${findJP(state.cameraMovement)}、シャッター：${findJP(state.shutterSpeed)}。`,
+    `スタイル：${findJP(state.style)}。カラーグレーディング：${findJP(state.colorGrade)}。`,
+    `レンダー仕上げ：${renderFinish.join("、") || "指定なし"}。${state.subjectConsistency ? "被写体の一貫性を保持。" : ""}${
+      state.extraJP?.trim() ? `備考：${state.extraJP.trim()}。` : ""
+    }`,
+  ]);
+  return lines.join("\n");
+};
 
-function buildJP(state) {
-  const parts = [
-    `美少女アニメのイラスト`,
-    `${findJP(state.characterType)}`,
-    `髪は${findJP(state.hairColor)}の${findJP(state.hairStyle)}`,
-    `瞳は${findJP(state.eyeColor)}`,
-    `${findJP(state.expression)}表情`,
-    `${findJP(state.pose)}`,
-    `${findJP(state.fashion)}`,
-    `背景:${findJP(state.background)}`,
-    `雰囲気:${findJP(state.mood)}`,
-    `ジャンル:${findJP(state.genre)}`,
-    `${findJP(state.details)}`,
-    `カメラ:${[state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean).map(findJP).join("、")}`,
-    `スタイル:${findJP(state.style)}`,
-  ];
-  return parts.join("、");
-}
-
-function buildAnimeJSON(state, EN) {
-  const details = {
-    character: {
-      type: state.characterType,
-      hair_color: state.hairColor,
-      hair_style: state.hairStyle,
-      eye_color: state.eyeColor,
-      expression: state.expression,
-      pose: state.pose,
-      fashion: state.fashion,
-      details: state.details,
-    },
-    scene: {
-      background: state.background,
-      mood: state.mood,
-      genre: state.genre,
-    },
-    camera: {
-      shot_distance: state.shotDistance,
-      shot_angle: state.shotAngle,
-      shot_style: state.shotStyle,
-    },
-    style: {
-      visual_style: state.style,
-    },
-  };
-
+const buildAnimeJSON = (state, EN) => {
+  const renderFinish = mergeMulti(state.renderFinish, state.renderFinishExtra);
   return {
     prompt: EN,
-    details,
+    details: {
+      character: {
+        type: state.characterType,
+        hair_color: state.hairColor,
+        hair_style: state.hairStyle,
+        eye_color: state.eyeColor,
+        expression: state.expression,
+        pose: state.pose,
+        fashion: state.fashion,
+        details: state.details,
+      },
+      scene: {
+        background: state.background,
+        mood: state.mood,
+        genre: state.genre,
+      },
+      camera: {
+        shot_distance: state.shotDistance,
+        shot_angle: state.shotAngle,
+        shot_style: state.shotStyle,
+        camera_movement: state.cameraMovement,
+        shutter_speed: state.shutterSpeed,
+      },
+      style: {
+        visual_style: state.style,
+        color_grade: state.colorGrade,
+      },
+      render: {
+        finish: renderFinish,
+      },
+      controls: {
+        subject_consistency: !!state.subjectConsistency,
+      },
+    },
     metadata: state,
   };
-}
+};
+
+const randomPick = (arr) => {
+  const pool = Array.isArray(arr) ? arr : [];
+  if (pool.length === 0) return "";
+  return pool[Math.floor(Math.random() * pool.length)].en;
+};
 
 export default function AnimePromptBuilder({ uiLang = "EN" }) {
   const [state, setState] = useState(defaultState);
-  const { copy } = useClipboard();
-
   const [lang, setLang] = useState("EN");
-  const [showPrompt, setShowPrompt] = useState(false);
+  const [presetOpen, setPresetOpen] = useState(false);
+  const englishRef = useRef(null);
+  const japaneseRef = useRef(null);
+  const { toast, highlightKey, copyWithFeedback } = useCopyFeedback(600);
 
   const EN = useMemo(() => buildEN(state), [state]);
   const JP = useMemo(() => buildJP(state), [state]);
+  const animeJSON = useMemo(() => buildAnimeJSON(state, EN), [state, EN]);
+  const englishHighlighted = highlightKey === "anime-en";
+  const japaneseHighlighted = highlightKey === "anime-jp";
 
   const exportJSON = () => {
-    const animeReady = buildAnimeJSON(state, EN);
-    const blob = new Blob([JSON.stringify(animeReady, null, 2)], {
-      type: "application/json",
-    });
+    const blob = new Blob([JSON.stringify(animeJSON, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -125,259 +168,400 @@ export default function AnimePromptBuilder({ uiLang = "EN" }) {
     URL.revokeObjectURL(url);
   };
 
-  function randomPick(arr) {
-    return arr[Math.floor(Math.random() * arr.length)].en;
-  }
-
   const randomize = () => {
-    setState({
-      characterType: randomPick(animeOptions.characterType),
-      hairColor: randomPick(animeOptions.hairColor),
-      hairStyle: randomPick(animeOptions.hairStyle),
-      eyeColor: randomPick(animeOptions.eyeColor),
-      expression: randomPick(animeOptions.expression),
-      pose: randomPick(animeOptions.pose),
-      fashion: randomPick(animeOptions.fashion),
-      background: randomPick(animeOptions.background),
-      mood: randomPick(animeOptions.mood),
-      genre: randomPick(animeOptions.genre),
-      details: randomPick(animeOptions.details),
-      shotDistance: randomPick(animeOptions.shotDistance),
-      shotAngle: randomPick(animeOptions.shotAngle),
-      shotStyle: Math.random() < 0.5 ? randomPick(animeOptions.shotStyle) : "",
-      style: randomPick(animeOptions.style),
+    setState((prev) => {
+      const base = defaultState();
+      return {
+        ...base,
+        characterType: randomPick(animeOptions.characterType),
+        hairColor: randomPick(animeOptions.hairColor),
+        hairStyle: randomPick(animeOptions.hairStyle),
+        eyeColor: randomPick(animeOptions.eyeColor),
+        expression: randomPick(animeOptions.expression),
+        pose: randomPick(animeOptions.pose),
+        fashion: randomPick(animeOptions.fashion),
+        background: randomPick(animeOptions.background),
+        mood: randomPick(animeOptions.mood),
+        genre: randomPick(animeOptions.genre),
+        details: randomPick(animeOptions.details),
+        shotDistance: randomPick(animeOptions.shotDistance),
+        shotAngle: randomPick(animeOptions.shotAngle),
+        shotStyle: Math.random() < 0.5 ? randomPick(animeOptions.shotStyle) : "",
+        style: randomPick(animeOptions.style),
+        cameraMovement: randomPick(animeOptions.cameraMovement),
+        shutterSpeed: randomPick(animeOptions.shutterSpeed),
+        colorGrade: randomPick(animeOptions.colorGrade),
+        renderFinish: [randomPick(animeOptions.renderFinish)],
+        subjectConsistency: prev.subjectConsistency,
+        extraEN: "",
+        extraJP: "",
+      };
     });
   };
 
-  const reset = () => setState(defaultState);
+  const reset = () => setState(defaultState());
 
-  const field = (label, node) => (
-    <div className="space-y-1">
-      <label className="text-xs font-medium text-gray-600">{label}</label>
-      {node}
-    </div>
-  );
+  const copyEnglish = () => {
+    const exec = () =>
+      copyWithFeedback(EN, {
+        element: englishRef,
+        label: "English copied",
+        failLabel: "Copy failed",
+      });
+    if (lang !== "EN" && typeof window !== "undefined") {
+      setLang("EN");
+      window.requestAnimationFrame(exec);
+    } else {
+      exec();
+    }
+  };
 
+  const copyJapanese = () => {
+    const exec = () =>
+      copyWithFeedback(JP, {
+        element: japaneseRef,
+        label: "日本語コピー",
+        failLabel: "コピー失敗",
+      });
+    if (lang !== "JP" && typeof window !== "undefined") {
+      setLang("JP");
+      window.requestAnimationFrame(exec);
+    } else {
+      exec();
+    }
+  };
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
-      <header className="sticky top-0 z-20 bg-white/80 backdrop-blur border-b">
-        <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+    <div className="min-h-screen bg-gray-50 text-gray-900 pb-28">
+      <PresetManager
+        open={presetOpen}
+        onClose={() => setPresetOpen(false)}
+        storageKey="anime-presets-v2"
+        currentState={state}
+        onApply={(next) => setState(cloneState(next))}
+        transformSave={cloneState}
+        transformLoad={cloneState}
+        title="Anime Presets"
+      />
+
+      <FloatingToast message={toast} />
+
+      <header className="sticky top-0 z-20 bg-white/90 backdrop-blur border-b">
+        <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Wand2 className="h-5 w-5" />
-            <h1 className="text-base sm:text-lg font-semibold">Anime Prompt Builder — EN/JP</h1>
+            <div>
+              <h1 className="text-base sm:text-lg font-semibold">Anime Prompt Builder — EN/JP</h1>
+              <p className="text-xs text-gray-500">Slot-structured EN prompt keeps translation stable.</p>
+            </div>
           </div>
           <div className="flex items-center gap-2">
-            <Button onClick={randomize} title="Randomize"><Shuffle className="h-4 w-4" />Random</Button>
-            <Button variant="subtle" onClick={reset} title="Reset"><RotateCcw className="h-4 w-4" />Reset</Button>
+            <Button onClick={randomize} title="Randomize anime prompt">
+              <Shuffle className="h-4 w-4" /> Random
+            </Button>
+            <Button variant="subtle" onClick={reset} title="Reset to defaults">
+              <RotateCcw className="h-4 w-4" /> Reset
+            </Button>
           </div>
         </div>
       </header>
 
-      <main className="max-w-6xl mx-auto px-4 pt-6 pb-32 grid grid-cols-1 xl:grid-cols-3 gap-6 items-start">
-          <div className="xl:col-span-2 space-y-6">
-            <Card>
-              <CardHeader title="Character" />
-              <CardContent className="space-y-3">
-                {field("Character Type", (
-                  <Select
-                    value={state.characterType}
-                    onChange={(v) => setState({ ...state, characterType: v })}
-                    options={toSelectOptions(animeOptions.characterType, uiLang)}
-                    allowCustom
-                  />
-                ))}
-                {field("Hair Color", (
-                  <Select
-                    value={state.hairColor}
-                    onChange={(v) => setState({ ...state, hairColor: v })}
-                    options={toSelectOptions(animeOptions.hairColor, uiLang)}
-                    allowCustom
-                  />
-                ))}
-                {field("Hair Style", (
-                  <Select
-                    value={state.hairStyle}
-                    onChange={(v) => setState({ ...state, hairStyle: v })}
-                    options={toSelectOptions(animeOptions.hairStyle, uiLang)}
-                    allowCustom
-                  />
-                ))}
-                {field("Eye Color", (
-                  <Select
-                    value={state.eyeColor}
-                    onChange={(v) => setState({ ...state, eyeColor: v })}
-                    options={toSelectOptions(animeOptions.eyeColor, uiLang)}
-                    allowCustom
-                  />
-                ))}
-                {field("Expression", (
-                  <Select
-                    value={state.expression}
-                    onChange={(v) => setState({ ...state, expression: v })}
-                    options={toSelectOptions(animeOptions.expression, uiLang)}
-                    allowCustom
-                  />
-                ))}
-                {field("Pose", (
-                  <Select
-                    value={state.pose}
-                    onChange={(v) => setState({ ...state, pose: v })}
-                    options={toSelectOptions(animeOptions.pose, uiLang)}
-                    allowCustom
-                  />
-                ))}
-                {field("Fashion", (
-                  <Select
-                    value={state.fashion}
-                    onChange={(v) => setState({ ...state, fashion: v })}
-                    options={toSelectOptions(animeOptions.fashion, uiLang)}
-                    allowCustom
-                  />
-                ))}
-                {field("Details", (
-                  <Select
-                    value={state.details}
-                    onChange={(v) => setState({ ...state, details: v })}
-                    options={toSelectOptions(animeOptions.details, uiLang)}
-                    allowCustom
-                  />
-                ))}
-              </CardContent>
-            </Card>
+      <main className="max-w-5xl mx-auto px-4 pt-6 grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+        <div className="lg:col-span-2 space-y-6">
+          <Card>
+            <CardHeader title="Character" subtitle="Core description for the hero or heroine." />
+            <CardContent className="grid sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Character type</label>
+                <Select
+                  value={state.characterType}
+                  onChange={(v) => setState({ ...state, characterType: v })}
+                  options={toSelectOptions(animeOptions.characterType, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Hair color</label>
+                <Select
+                  value={state.hairColor}
+                  onChange={(v) => setState({ ...state, hairColor: v })}
+                  options={toSelectOptions(animeOptions.hairColor, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Hair style</label>
+                <Select
+                  value={state.hairStyle}
+                  onChange={(v) => setState({ ...state, hairStyle: v })}
+                  options={toSelectOptions(animeOptions.hairStyle, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Eye color</label>
+                <Select
+                  value={state.eyeColor}
+                  onChange={(v) => setState({ ...state, eyeColor: v })}
+                  options={toSelectOptions(animeOptions.eyeColor, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Expression</label>
+                <Select
+                  value={state.expression}
+                  onChange={(v) => setState({ ...state, expression: v })}
+                  options={toSelectOptions(animeOptions.expression, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Pose</label>
+                <Select
+                  value={state.pose}
+                  onChange={(v) => setState({ ...state, pose: v })}
+                  options={toSelectOptions(animeOptions.pose, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Fashion</label>
+                <Select
+                  value={state.fashion}
+                  onChange={(v) => setState({ ...state, fashion: v })}
+                  options={toSelectOptions(animeOptions.fashion, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Special details</label>
+                <Select
+                  value={state.details}
+                  onChange={(v) => setState({ ...state, details: v })}
+                  options={toSelectOptions(animeOptions.details, uiLang)}
+                />
+              </div>
+            </CardContent>
+          </Card>
 
-            <Card>
-              <CardHeader title="Scene" />
-              <CardContent className="space-y-3">
-                {field("Background", (
-                  <Select
-                    value={state.background}
-                    onChange={(v) => setState({ ...state, background: v })}
-                    options={toSelectOptions(animeOptions.background, uiLang)}
-                    allowCustom
-                  />
-                ))}
-                {field("Mood", (
-                  <Select
-                    value={state.mood}
-                    onChange={(v) => setState({ ...state, mood: v })}
-                    options={toSelectOptions(animeOptions.mood, uiLang)}
-                    allowCustom
-                  />
-                ))}
-              </CardContent>
-            </Card>
+          <Card>
+            <CardHeader title="Scene & Mood" subtitle="Background, tone, and movement." />
+            <CardContent className="grid sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Background</label>
+                <Select
+                  value={state.background}
+                  onChange={(v) => setState({ ...state, background: v })}
+                  options={toSelectOptions(animeOptions.background, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Mood</label>
+                <Select
+                  value={state.mood}
+                  onChange={(v) => setState({ ...state, mood: v })}
+                  options={toSelectOptions(animeOptions.mood, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Genre</label>
+                <Select
+                  value={state.genre}
+                  onChange={(v) => setState({ ...state, genre: v })}
+                  options={toSelectOptions(animeOptions.genre, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Camera movement</label>
+                <Select
+                  value={state.cameraMovement}
+                  onChange={(v) => setState({ ...state, cameraMovement: v })}
+                  options={toSelectOptions(animeOptions.cameraMovement, uiLang)}
+                />
+              </div>
+            </CardContent>
+          </Card>
 
-            <Card>
-              <CardHeader title="Genre" />
-              <CardContent className="space-y-3">
-                {field("Genre", (
-                  <Select
-                    value={state.genre}
-                    onChange={(v) => setState({ ...state, genre: v })}
-                    options={toSelectOptions(animeOptions.genre, uiLang)}
-                    allowCustom
-                  />
-                ))}
-                {field("Style", (
-                  <Select
-                    value={state.style}
-                    onChange={(v) => setState({ ...state, style: v })}
-                    options={toSelectOptions(animeOptions.style, uiLang)}
-                    allowCustom
-                  />
-                ))}
-              </CardContent>
-            </Card>
+          <Card>
+            <CardHeader title="Camera" subtitle="Shot selection and shutter." />
+            <CardContent className="grid sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Shot distance</label>
+                <Select
+                  value={state.shotDistance}
+                  onChange={(v) => setState({ ...state, shotDistance: v })}
+                  options={toSelectOptions(animeOptions.shotDistance, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Shot angle</label>
+                <Select
+                  value={state.shotAngle}
+                  onChange={(v) => setState({ ...state, shotAngle: v })}
+                  options={toSelectOptions(animeOptions.shotAngle, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Shot style</label>
+                <Select
+                  value={state.shotStyle}
+                  onChange={(v) => setState({ ...state, shotStyle: v })}
+                  options={toSelectOptions(animeOptions.shotStyle, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Shutter</label>
+                <Select
+                  value={state.shutterSpeed}
+                  onChange={(v) => setState({ ...state, shutterSpeed: v })}
+                  options={toSelectOptions(animeOptions.shutterSpeed, uiLang)}
+                />
+              </div>
+            </CardContent>
+          </Card>
 
-            <Card>
-              <CardHeader title="Camera" />
-              <CardContent className="space-y-3">
-                {field("Shot Distance", (
-                  <Select
-                    value={state.shotDistance}
-                    onChange={(v) => setState({ ...state, shotDistance: v })}
-                    options={toSelectOptions(animeOptions.shotDistance, uiLang)}
+          <Card>
+            <CardHeader title="Style & Render" subtitle="Visual finish and consistency toggle." />
+            <CardContent className="grid sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Visual style</label>
+                <Select
+                  value={state.style}
+                  onChange={(v) => setState({ ...state, style: v })}
+                  options={toSelectOptions(animeOptions.style, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Color grade</label>
+                <Select
+                  value={state.colorGrade}
+                  onChange={(v) => setState({ ...state, colorGrade: v })}
+                  options={toSelectOptions(animeOptions.colorGrade, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Render finish</label>
+                <Select
+                  value={state.renderFinish[0]}
+                  onChange={(v) => setState({ ...state, renderFinish: [v] })}
+                  options={toSelectOptions(animeOptions.renderFinish, uiLang)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-600">Extra render notes</label>
+                <Input
+                  value={state.renderFinishExtra}
+                  onChange={(v) => setState({ ...state, renderFinishExtra: v })}
+                  placeholder="e.g. add subtle grain"
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="text-xs font-medium text-gray-600">Subject consistency</label>
+                <div className="mt-2">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 mr-2"
+                    checked={state.subjectConsistency}
+                    onChange={(e) => setState({ ...state, subjectConsistency: e.target.checked })}
                   />
-                ))}
-                {field("Angle", (
-                  <Select
-                    value={state.shotAngle}
-                    onChange={(v) => setState({ ...state, shotAngle: v })}
-                    options={toSelectOptions(animeOptions.shotAngle, uiLang)}
-                  />
-                ))}
-                {field("Special", (
-                  <Select
-                    value={state.shotStyle}
-                    onChange={(v) => setState({ ...state, shotStyle: v })}
-                    options={toSelectOptions(animeOptions.shotStyle, uiLang)}
-                  />
-                ))}
-              </CardContent>
-            </Card>
-          </div>
+                  <span className="text-sm">Keep subject identity consistent for remix clips</span>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader title="Notes" subtitle="Optional extra notes." />
+            <CardContent className="grid sm:grid-cols-2 gap-4">
+              <Textarea
+                value={state.extraEN}
+                onChange={(v) => setState({ ...state, extraEN: v })}
+                placeholder="Extra English notes"
+                rows={3}
+              />
+              <Textarea
+                value={state.extraJP}
+                onChange={(v) => setState({ ...state, extraJP: v })}
+                placeholder="日本語での補足"
+                rows={3}
+              />
+            </CardContent>
+          </Card>
+        </div>
 
         <div className="space-y-6">
-          {showPrompt && (
-            <Card className="fixed bottom-16 left-0 right-0 bg-white z-10">
-              <CardHeader
-                title={lang === "EN" ? "English Prompt" : "日本語プロンプト"}
-                right={
-                  <div className="flex gap-2">
-                    <Button variant={lang === "EN" ? "default" : "subtle"} onClick={() => setLang("EN")}>
-                      EN
-                    </Button>
-                    <Button variant={lang === "JP" ? "default" : "subtle"} onClick={() => setLang("JP")}>
-                      JP
-                    </Button>
-                  </div>
-                }
-              />
-              <CardContent>
-                <div className="flex items-center justify-between mb-3">
-                  {lang === "EN" ? (
-                    <div className="text-xs text-gray-500">English prompt</div>
-                  ) : (
-                    <div className="flex items-center gap-2 text-xs text-gray-500">
-                      <Languages className="h-4 w-4" />内蔵変換 (機械翻訳API不使用)
-                    </div>
-                  )}
-                  <div className="flex gap-2">
-                    <Button
-                      variant="ghost"
-                      onClick={() =>
-                        copy(
-                          JSON.stringify(buildAnimeJSON(state, EN), null, 2)
-                        )
-                      }
-                      title="Copy JSON"
-                    >
-                      <Copy className="h-4 w-4" />
-                      {lang === "EN" ? "Copy JSON" : "JSONコピー"}
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      onClick={exportJSON}
-                      title="Export JSON"
-                    >
-                      <Download className="h-4 w-4" />
-                      Export
-                    </Button>
-                  </div>
+          <Card>
+            <CardHeader
+              title={lang === "EN" ? "English Prompt" : "日本語プロンプト"}
+              subtitle="Optimised order for Sora"
+              right={
+                <div className="flex items-center gap-2">
+                  <Button variant={lang === "EN" ? "default" : "subtle"} onClick={() => setLang("EN")}>
+                    EN
+                  </Button>
+                  <Button variant={lang === "JP" ? "default" : "subtle"} onClick={() => setLang("JP")}>
+                    JP
+                  </Button>
                 </div>
-                <Textarea value={lang === "EN" ? EN : JP} onChange={() => {}} rows={14} className="font-mono" />
-              </CardContent>
-            </Card>
-          )}
+              }
+            />
+            <CardContent className="space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-500">
+                <div>Order: subject → scene → camera → style → render</div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    onClick={() => copyWithFeedback(JSON.stringify(animeJSON, null, 2), { label: "JSON copied" })}
+                    title="Copy JSON"
+                  >
+                    <Copy className="h-4 w-4" /> JSON
+                  </Button>
+                  <Button variant="ghost" onClick={exportJSON} title="Export JSON">
+                    <Download className="h-4 w-4" /> Export
+                  </Button>
+                </div>
+              </div>
+              <div className="relative">
+                <Textarea
+                  value={EN}
+                  onChange={() => {}}
+                  readOnly
+                  rows={12}
+                  inputRef={englishRef}
+                  highlight={englishHighlighted && lang === "EN"}
+                  highlightKey="anime-en"
+                  className={`font-mono transition-opacity ${
+                    lang === "EN" ? "opacity-100" : "opacity-0 pointer-events-none absolute inset-0"
+                  }`}
+                />
+                <Textarea
+                  value={JP}
+                  onChange={() => {}}
+                  readOnly
+                  rows={14}
+                  inputRef={japaneseRef}
+                  highlight={japaneseHighlighted && lang === "JP"}
+                  highlightKey="anime-jp"
+                  className={`font-mono transition-opacity ${
+                    lang === "JP" ? "opacity-100" : "opacity-0 pointer-events-none absolute inset-0"
+                  }`}
+                />
+              </div>
+            </CardContent>
+          </Card>
         </div>
       </main>
 
-      <Button
-        className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-20"
-        onClick={() => setShowPrompt((p) => !p)}
-      >
-        {showPrompt ? "Hide Prompt" : "Show Prompt"}
-      </Button>
+      <ActionBar>
+        <Button onClick={copyEnglish}>
+          <Copy className="h-4 w-4" /> EN
+        </Button>
+        <Button onClick={copyJapanese}>
+          <Languages className="h-4 w-4" /> JP
+        </Button>
+        <Button variant="subtle" onClick={() => setPresetOpen(true)}>
+          <Layers className="h-4 w-4" /> Presets
+        </Button>
+        <Button variant="subtle" onClick={reset}>
+          <RotateCcw className="h-4 w-4" /> Reset
+        </Button>
+        <Button variant="subtle" onClick={randomize}>
+          <Shuffle className="h-4 w-4" /> Random
+        </Button>
+      </ActionBar>
     </div>
   );
 }

--- a/src/SoraPromptBuilder.jsx
+++ b/src/SoraPromptBuilder.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import {
   Copy,
   Shuffle,
@@ -8,6 +8,7 @@ import {
   Wand2,
   CameraOff,
   EyeOff,
+  Layers,
 } from "lucide-react";
 import {
   Card,
@@ -18,28 +19,39 @@ import {
   Input,
   Textarea,
   Toggle,
+  ActionBar,
+  FloatingToast,
 } from "./components/ui";
+import PresetManager from "./components/PresetManager.jsx";
 import { options, toSelectOptions, findJP } from "./data/options";
+import { useCopyFeedback } from "./hooks/useCopyFeedback.js";
+import { listToOxford, normalizeEnglish, compactSegments } from "./utils/text.js";
 
-function useClipboard() {
-  const copy = async (text) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-  return { copy };
-}
+const apertureFromDof = (dof) => {
+  const clamped = Math.max(0, Math.min(100, Number.isFinite(dof) ? dof : 35));
+  const f = Math.round(1.2 + (clamped / 100) * 10 * 10) / 10;
+  return `f/${f.toFixed(1)}`;
+};
 
+const pref = (value, manual) => {
+  const manualStr = manual && String(manual).trim();
+  if (manualStr) return manualStr;
+  const valueStr = value && String(value).trim();
+  return valueStr || "";
+};
 
-// ===== DEFAULT STATE (extended for candid & static camera) =====
-const defaultState = {
-  // Character
+const mergeMulti = (list = [], extra) => {
+  const items = Array.isArray(list) ? list.filter(Boolean) : [];
+  const extraStr = extra && String(extra).trim();
+  if (extraStr) items.push(extraStr);
+  return items.filter(Boolean);
+};
+
+const defaultState = () => ({
   age: "",
   ageManual: "",
   gender: "female",
+  genderManual: "",
   ethnicity: "Japanese",
   ethnicityManual: "",
   face: ["natural features", "soft oval face", "light freckles"],
@@ -53,7 +65,6 @@ const defaultState = {
   eyeColor: "dark brown",
   eyeColorManual: "",
 
-  // Outfit
   tops: "fitted light gray long-sleeve, slightly open neckline",
   topsManual: "",
   bottoms: "dark trousers",
@@ -62,39 +73,44 @@ const defaultState = {
   dressManual: "",
   outer: "",
   outerManual: "",
-  accessories: ["no accessories"],
+  accessories: [],
   accessoriesExtra: "",
   fashionVibe: "fashionable",
   fashionVibeManual: "",
 
-  // Scene
   background: "cozy room with large window",
   backgroundManual: "",
   bgDetails: ["wooden desk", "soft clutter of books and notes"],
   bgDetailsExtra: "",
   crowd: false,
 
-  // Action
-  activity: "studying and writing in a notebook",
+  activity: ["studying and writing in a notebook"],
   activityManual: "",
 
-  // Camera
   shotDistance: "Medium Shot (MS)",
   shotAngle: "",
   shotStyle: "",
   shotManual: "",
   lens: "",
   focalLength: 50,
-  dofStrength: 35, // 0–100
+  dofStrength: 35,
   focusSubject: "eyes",
 
-  // Movement & candid controls
-  staticCamera: true, // lock camera (no zoom/pan)
-  tripod: true, // locked-off tripod style
-  forbidEyeContact: false, // never look toward camera
-  candidMode: "none", // "none" | "far" | "close"
+  staticCamera: true,
+  tripod: true,
+  forbidEyeContact: false,
+  candidMode: "none",
 
-  // Lighting / Mood / Style
+  cameraMovement: ["locked static frame"],
+  cameraMovementManual: "",
+  shutterSpeed: "1/48s (180° shutter, natural motion blur)",
+  shutterManual: "",
+  colorGrade: "neutral cinematic grade",
+  colorGradeManual: "",
+  renderFinish: ["deliver in 4K UHD, 24fps master"],
+  renderFinishExtra: "",
+  subjectConsistency: false,
+
   lighting: "soft desk lamp + ambient practicals",
   lightingManual: "",
   mood: "calm and focused",
@@ -102,257 +118,307 @@ const defaultState = {
   style: ["photorealistic, ultra-detailed, natural skin texture", "cinematic color grading"],
   styleExtra: "",
 
-  // Output
   extraEN: "",
   extraJP: "",
+});
+
+const cloneState = (state) => JSON.parse(JSON.stringify(state));
+
+const buildEnglishPrompt = (state) => {
+  const faceList = mergeMulti(state.face, state.faceExtra);
+  const hairList = mergeMulti(state.hairStyle, state.hairExtra);
+  const accessories = mergeMulti(
+    (state.accessories || []).filter((item) => item && item !== "no accessories"),
+    state.accessoriesExtra
+  );
+  const bgDetails = mergeMulti(state.bgDetails, state.bgDetailsExtra);
+  const styleList = mergeMulti(state.style, state.styleExtra);
+  const renderFinish = mergeMulti(state.renderFinish, state.renderFinishExtra);
+  const cameraMovement = mergeMulti(state.cameraMovement, state.cameraMovementManual);
+  const actions = mergeMulti(state.activity, state.activityManual);
+
+  const identityParts = compactSegments([
+    pref(state.age, state.ageManual),
+    pref(state.gender, state.genderManual),
+    pref(state.ethnicity, state.ethnicityManual),
+  ]);
+  const identity = identityParts.join(" ");
+  const hairColor = pref(state.hairColor, state.hairColorManual);
+  const makeup = pref(state.makeup, state.makeupManual);
+  const eyeColor = pref(state.eyeColor, state.eyeColorManual);
+  const fashionVibe = pref(state.fashionVibe, state.fashionVibeManual);
+  const background = pref(state.background, state.backgroundManual);
+  const lighting = pref(state.lighting, state.lightingManual);
+  const mood = pref(state.mood, state.moodManual);
+  const colorGrade = pref(state.colorGrade, state.colorGradeManual);
+  const shutter = pref(state.shutterSpeed, state.shutterManual);
+
+  const outfitBase = pref(state.dress, state.dressManual)
+    ? pref(state.dress, state.dressManual)
+    : compactSegments([pref(state.tops, state.topsManual), pref(state.bottoms, state.bottomsManual)]).join(" and ");
+  const outer = pref(state.outer, state.outerManual);
+  const outfit = compactSegments([outfitBase, outer ? `with ${outer}` : ""]).join(" ");
+  const accessoriesText = accessories.length ? `accessorised with ${listToOxford(accessories)}` : "";
+
+  const subjectSegment = compactSegments([
+    identity ? `A ${identity}` : "A subject",
+    faceList.length ? `featuring ${listToOxford(faceList)}` : "",
+    hairList.length ? `hair styled ${listToOxford(hairList)}` : "",
+    hairColor ? `${hairColor} hair` : "",
+    makeup ? makeup : "",
+    eyeColor ? `${eyeColor} eyes` : "",
+    outfit ? `wearing ${outfit}` : "",
+    accessoriesText,
+    fashionVibe ? `overall vibe ${fashionVibe}` : "",
+    actions.length ? `performing ${listToOxford(actions)}` : "",
+  ]).join(", ");
+
+  const locationSegment = compactSegments([
+    background ? `Set in ${background}` : "",
+    bgDetails.length ? `featuring ${listToOxford(bgDetails)}` : "",
+    state.crowd ? "with background passersby" : "with no background crowd",
+  ]).join(", ");
+
+  const shotParts = compactSegments([
+    state.shotManual?.trim(),
+    [state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean).join(", "),
+  ]);
+  const lens = state.lens || `${state.focalLength}mm lens`;
+  const aperture = apertureFromDof(state.dofStrength);
+  const movementText = cameraMovement.length ? `with ${listToOxford(cameraMovement)}` : "";
+  const controlFlags = compactSegments([
+    state.staticCamera ? "static locked-off framing" : "",
+    state.tripod && !state.staticCamera ? "tripod stabilised" : "",
+    state.forbidEyeContact ? "no direct eye contact" : "",
+    state.candidMode === "far" ? "documentary candid distance" : "",
+    state.candidMode === "close" ? "intimate candid proximity" : "",
+  ]);
+
+  const cameraSegment = compactSegments([
+    shotParts.length ? `Captured as ${shotParts.join(" / ")}` : "Captured shot",
+    `using a ${lens}`,
+    movementText,
+    `depth of field ${state.dofStrength}/100 (${aperture})`,
+    `focus locked on ${state.focusSubject}`,
+    shutter ? `shutter ${shutter}` : "",
+    controlFlags.length ? `controls: ${listToOxford(controlFlags)}` : "",
+    state.subjectConsistency ? "maintain subject continuity across edits" : "",
+  ]).join(", ");
+
+  const lightingSegment = lighting ? `Lighting: ${lighting}` : "";
+  const moodSegment = compactSegments([
+    mood ? `Mood: ${mood}` : "",
+    state.candidMode !== "none" ? "keep candid, unposed energy" : "",
+  ]).join(", ");
+
+  const qualitySegment = compactSegments([
+    styleList.length ? `Visual style: ${listToOxford(styleList)}` : "",
+    colorGrade ? `Color grade: ${colorGrade}` : "",
+  ]).join(", ");
+
+  const renderSegmentParts = [
+    renderFinish.length ? `Render finish: ${listToOxford(renderFinish)}` : "",
+    "Strictly photorealistic rendering with natural skin texture, realistic fabric folds, detailed hair strands",
+    state.extraEN?.trim() ? `Notes: ${state.extraEN.trim()}` : "",
+  ].filter(Boolean);
+  const renderSegment = renderSegmentParts.join(". ");
+
+  const segments = compactSegments([
+    subjectSegment,
+    locationSegment,
+    cameraSegment,
+    lightingSegment,
+    moodSegment,
+    qualitySegment,
+    renderSegment,
+  ]);
+
+  return normalizeEnglish(segments.join(". "));
 };
 
-// ===== HELPERS =====
-function apertureFromDof(dof) {
-  // Maps 0..100 to ~f/1.2 .. f/11.2 (simple & intuitive)
-  const f = Math.round(1.2 + (Math.max(0, Math.min(100, dof)) / 100) * 10 * 10) / 10;
-  return `f/${f.toFixed(1)}`;
-}
-function pref(value, manual) {
-  const candidate = (manual && String(manual).trim()) || (value && String(value).trim());
-  return candidate ? candidate : value;
-}
+const buildJapanesePrompt = (state) => {
+  const faceArr = mergeMulti(state.face.map(findJP), state.faceExtra);
+  const hairArr = mergeMulti(state.hairStyle.map(findJP), state.hairExtra);
+  const accessories = mergeMulti(
+    (state.accessories || []).filter((item) => item && item !== "no accessories").map(findJP),
+    state.accessoriesExtra
+  );
+  const bgArr = mergeMulti(state.bgDetails.map(findJP), state.bgDetailsExtra);
+  const styleArr = mergeMulti(state.style.map(findJP), state.styleExtra);
+  const renderFinish = mergeMulti(state.renderFinish.map(findJP), state.renderFinishExtra);
+  const movementArr = mergeMulti(state.cameraMovement.map(findJP), state.cameraMovementManual);
+  const actionArr = mergeMulti(state.activity.map(findJP), state.activityManual && findJP(state.activityManual));
 
-function buildEnglishPrompt(state) {
-  // Multi lists with optional extra
-  const hairList = state.hairStyle.filter(Boolean);
-  if (state.hairExtra?.trim()) hairList.push(state.hairExtra.trim());
-  const faceList = state.face.filter(Boolean);
-  if (state.faceExtra?.trim()) faceList.push(state.faceExtra.trim());
-  const accList = state.accessories.filter((a) => a && a !== "no accessories");
-  if (state.accessoriesExtra?.trim()) accList.push(state.accessoriesExtra.trim());
-
-  const hair = hairList.join(", ");
-  const face = faceList.join(", ");
-  const acc = accList.join(", ");
-  const accText = acc ? `, wearing ${acc}` : "";
-  const outerText = pref(state.outer, state.outerManual) ? `, with ${pref(state.outer, state.outerManual)}` : "";
-  const crowd = state.crowd ? "with background passersby present" : "no background people";
-
-  const bgdList = state.bgDetails.filter(Boolean);
-  if (state.bgDetailsExtra?.trim()) bgdList.push(state.bgDetailsExtra.trim());
-  const bgText = bgdList.length ? `, ${bgdList.join(", ")}` : "";
-
-  const styleList = state.style.filter(Boolean);
-  if (state.styleExtra?.trim()) styleList.push(state.styleExtra.trim());
-  const style = styleList.join(", ");
-  const aperture = apertureFromDof(state.dofStrength);
-
-  // Camera motion & candid strings
-  const staticStr = state.staticCamera
-    ? ", static locked-off tripod shot, no zoom, no panning, no dolly, no push-in, absolutely no handheld shake or micro jitter, zero camera motion of any kind; composition never changes, like CCTV or a still photograph"
-    : "";
-  const tripodStr = state.tripod && !state.staticCamera ? ", tripod shot (no handheld shake)" : "";
-  const forbidEyeStr = state.forbidEyeContact ? ", excluding any direct eye contact with the viewer" : "";
-  let candidStr = "";
-  if (state.candidMode === "far") {
-    candidStr = ", captured documentary-style from a discreet distance as an unaware candid moment";
-  } else if (state.candidMode === "close") {
-    candidStr = ", candid close proximity as if peeking into her private space, unposed and unaware";
-  }
-
-  const moodExtra = state.candidMode !== "none" ? ", candid, natural, unposed" : "";
-
-  const shotParts = [state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean);
-  const shotCombined = shotParts.join(", ");
-  const fullBodyGuarantee = ["Long Shot (LS)", "Extreme Long Shot (ELS)"].includes(state.shotDistance)
-    ? ", the entire figure fully visible from head to toe, never cropped"
-    : "";
-  const actionRepetition = ", the motion is clearly captured and repeated continuously as a central sustained action";
-
-  const subjectParts = [];
   const age = pref(state.age, state.ageManual);
   const gender = pref(state.gender, state.genderManual);
   const ethnicity = pref(state.ethnicity, state.ethnicityManual);
-  if (age) subjectParts.push(age);
-  if (gender) subjectParts.push(gender);
-  if (ethnicity) subjectParts.push(ethnicity);
-  const subject = subjectParts.join(" ");
-
-  const dress = pref(state.dress, state.dressManual);
-  const outfit = dress
-    ? `${dress}${outerText}${accText}`
-    : `${pref(state.tops, state.topsManual)}, ${pref(state.bottoms, state.bottomsManual)}${outerText}${accText}`;
-  const fashionVibe = pref(state.fashionVibe, state.fashionVibeManual);
-
-  const lines = [
-    `A ${subject} subject with ${face}.`,
-    `Hairstyle: ${hair}. Hair color: ${pref(state.hairColor, state.hairColorManual)}. Makeup: ${pref(state.makeup, state.makeupManual)}. Eye color: ${pref(state.eyeColor, state.eyeColorManual)}.`,
-    `Outfit: ${outfit}.`,
-    fashionVibe ? `Fashion vibe: ${fashionVibe}.` : "",
-    `Scene: ${pref(state.background, state.backgroundManual)}${bgText}; ${crowd}.`,
-    `Action: ${pref(state.activity, state.activityManual)}${actionRepetition}${state.forbidEyeContact ? ", never looking toward the camera" : ""}.`,
-    `Camera: ${pref(shotCombined, state.shotManual)}, ${state.lens || `${state.focalLength}mm lens`}, ${aperture}, focus on ${state.focusSubject}${staticStr}${tripodStr}${candidStr}${forbidEyeStr}${fullBodyGuarantee}.`,
-    `Lighting: ${pref(state.lighting, state.lightingManual)}. Mood: ${pref(state.mood, state.moodManual)}${moodExtra}. Visual style: ${style}.`,
-  ];
-
-  const base = lines.filter(Boolean).join(" \n");
-  const extra = state.extraEN?.trim() ? `\nNotes: ${state.extraEN.trim()}` : "";
-  return (
-    base +
-    extra +
-    "\nStrictly photorealistic rendering with natural skin texture, realistic fabric folds, detailed hair strands. No cartoon or anime features."
-  );
-}
-
-function buildJapanesePrompt(state) {
-  const hairArr = state.hairStyle.map(findJP).filter(Boolean);
-  if (state.hairExtra?.trim()) hairArr.push(state.hairExtra.trim());
-  const faceArr = state.face.map(findJP).filter(Boolean);
-  if (state.faceExtra?.trim()) faceArr.push(state.faceExtra.trim());
-
-  const accArr = state.accessories.filter((a) => a && a !== "no accessories").map(findJP);
-  if (state.accessoriesExtra?.trim()) accArr.push(state.accessoriesExtra.trim());
-  const accText = accArr.length ? `、アクセサリーは${accArr.join("、")}` : "";
-
-  const outerJP = pref(state.outer, state.outerManual) ? findJP(pref(state.outer, state.outerManual)) : "";
-  const outerText = outerJP ? `、アウターは${outerJP}` : "";
-  const crowd = state.crowd ? "背景には通行人がいる" : "背景に人物はいない";
-
-  const bgdArr = state.bgDetails.map(findJP).filter(Boolean);
-  if (state.bgDetailsExtra?.trim()) bgdArr.push(state.bgDetailsExtra.trim());
-  const bgText = bgdArr.length ? `、${bgdArr.join("、")}` : "";
-
-  const styleArr = state.style.map(findJP).filter(Boolean);
-  if (state.styleExtra?.trim()) styleArr.push(state.styleExtra.trim());
-  const aperture = apertureFromDof(state.dofStrength);
-
-  const staticStr = state.staticCamera ? "、カメラは固定 - 三脚使用。ズーム・パン・ドリー・プッシュイン・手ブレ・微揺れ一切なし。構図は終始不変でCCTVや静止写真のよう" : "";
-  const tripodStr = state.tripod && !state.staticCamera ? "、三脚で手ブレなし" : "";
-  const forbidEyeStr = state.forbidEyeContact ? "、カメラ目線は一切なし" : "";
-  let candidStr = "";
-  if (state.candidMode === "far") candidStr = "、離れた位置からのドキュメンタリー風の観察ショット";
-  else if (state.candidMode === "close") candidStr = "、至近距離から覗き見るようなアンポーズの密着ショット";
-  const moodExtra = state.candidMode !== "none" ? "、スナップ的・自然体・演出感のない雰囲気" : "";
-
-  const shotPartsJP = [state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean);
-  const fullBodyGuarantee = ["Long Shot (LS)", "Extreme Long Shot (ELS)"].includes(state.shotDistance)
-    ? "、頭からつま先まで完全に写っており、クロップされない"
+  const identity = compactSegments([age ? findJP(age) : "", findJP(gender), findJP(ethnicity)]).join("・");
+  const hairColor = findJP(pref(state.hairColor, state.hairColorManual));
+  const makeup = findJP(pref(state.makeup, state.makeupManual));
+  const eyeColor = findJP(pref(state.eyeColor, state.eyeColorManual));
+  const fashionVibe = pref(state.fashionVibe, state.fashionVibeManual)
+    ? findJP(pref(state.fashionVibe, state.fashionVibeManual))
     : "";
-  const actionRepetition = "。動作は明確に画面に収められ、繰り返し持続的に主要な要素として強調される";
+  const background = findJP(pref(state.background, state.backgroundManual));
+  const lighting = findJP(pref(state.lighting, state.lightingManual));
+  const mood = findJP(pref(state.mood, state.moodManual));
+  const colorGrade = findJP(pref(state.colorGrade, state.colorGradeManual));
+  const shutter = findJP(pref(state.shutterSpeed, state.shutterManual));
 
-  const lensJP = state.lens ? findJP(state.lens) : `${state.focalLength}mm`;
-
-  const ageJP = pref(state.age, state.ageManual);
-  const subjectLine = `${ageJP ? findJP(ageJP) + "の" : ""}${findJP(pref(state.gender, state.genderManual))}、${findJP(pref(state.ethnicity, state.ethnicityManual))}の雰囲気。顔立ち：${faceArr.join("、")}。`;
-
-  const dressJP = pref(state.dress, state.dressManual)
+  const outfitBase = pref(state.dress, state.dressManual)
     ? findJP(pref(state.dress, state.dressManual))
-    : "";
-  const outfitJP = dressJP
-    ? `${dressJP}${outerText}${accText}`
-    : `${findJP(pref(state.tops, state.topsManual))}、${findJP(pref(state.bottoms, state.bottomsManual))}${outerText}${accText}`;
-  const fashionJP = pref(state.fashionVibe, state.fashionVibeManual);
+    : compactSegments([findJP(pref(state.tops, state.topsManual)), findJP(pref(state.bottoms, state.bottomsManual))]).join("・");
+  const outer = pref(state.outer, state.outerManual) ? findJP(pref(state.outer, state.outerManual)) : "";
+  const outfit = compactSegments([outfitBase, outer]).join("・");
+  const accessoryJP = accessories.length ? `アクセサリー：${accessories.join("、")}` : "";
 
-  const lines = [
-    subjectLine,
-    `ヘア：${hairArr.join("、")}。髪色：${findJP(pref(state.hairColor, state.hairColorManual))}。メイク：${findJP(pref(state.makeup, state.makeupManual))}。瞳の色：${findJP(pref(state.eyeColor, state.eyeColorManual))}。`,
-    `服装：${outfitJP}。`,
-    fashionJP ? `ファッションの雰囲気：${findJP(fashionJP)}。` : "",
-    `シーン：${findJP(pref(state.background, state.backgroundManual))}${bgText}。${crowd}。`,
-    `動作：${findJP(pref(state.activity, state.activityManual))}${actionRepetition}${state.forbidEyeContact ? "。視線は対象に固定され、カメラを見ることはない" : ""}。`,
-    `カメラ：${state.shotManual?.trim() ? state.shotManual : shotPartsJP.map(findJP).join("、")}、${lensJP}、${aperture}、フォーカスは${state.focusSubject}${staticStr}${tripodStr}${candidStr}${forbidEyeStr}${fullBodyGuarantee}。`,
-    `ライティング：${findJP(pref(state.lighting, state.lightingManual))}。ムード：${findJP(pref(state.mood, state.moodManual))}${moodExtra}。ビジュアル：${styleArr.join("、")}。`,
-  ];
+  const shotParts = compactSegments([
+    state.shotManual?.trim(),
+    [state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean).map(findJP).join("、"),
+  ]);
+  const lensJP = state.lens ? findJP(state.lens) : `${state.focalLength}mm`;
+  const aperture = apertureFromDof(state.dofStrength);
+  const controlFlags = compactSegments([
+    state.staticCamera ? "カメラは完全固定" : "",
+    state.tripod && !state.staticCamera ? "三脚で安定" : "",
+    state.forbidEyeContact ? "カメラ目線は禁止" : "",
+    state.candidMode === "far" ? "遠目からのドキュメンタリー観察" : "",
+    state.candidMode === "close" ? "覗き見るような至近距離のスナップ感" : "",
+    state.subjectConsistency ? "被写体の一貫性を維持" : "",
+  ]).join("、");
 
-  const base = lines.filter(Boolean).join("\n");
-  const extra = state.extraJP?.trim() ? `\n備考: ${state.extraJP.trim()}` : "";
-  return (
-    base +
-    extra +
-    "\n超写実的で自然な肌質、現実的な布のしわ、髪の1本1本まで丁寧に。アニメ・イラスト的表現は不可。"
+  const lines = compactSegments([
+    identity ? `${identity}の被写体。顔立ち：${faceArr.join("、")}` : `被写体。顔立ち：${faceArr.join("、")}`,
+    `ヘアスタイル：${hairArr.join("、")}。髪色：${hairColor}。メイク：${makeup}。瞳：${eyeColor}。`,
+    `服装：${outfit}。${accessoryJP}`,
+    fashionVibe ? `ファッションムード：${fashionVibe}。` : "",
+    `ロケーション：${background}${bgArr.length ? `、${bgArr.join("、")}` : ""}。${state.crowd ? "背景には通行人がいる" : "背景に人物はいない"}。`,
+    actionArr.length ? `被写体のアクション：${actionArr.join("、")}。` : "",
+    `カメラ：${shotParts.join("／") || "構図指定"}、${lensJP}、被写界深度${state.dofStrength}/100（${aperture}）、フォーカスは${state.focusSubject}。` +
+      (shutter ? `シャッター：${shutter}。` : "") +
+      (movementArr.length ? `カメラワーク：${movementArr.join("、")}。` : "") +
+      (controlFlags ? `${controlFlags}。` : ""),
+    `ライティング：${lighting}。ムード：${mood}${state.candidMode !== "none" ? "。演出感を抑え自然体を保つ" : ""}。`,
+    `ビジュアルスタイル：${styleArr.join("、")}。カラーグレーディング：${colorGrade}。`,
+    `レンダー仕上げ：${renderFinish.join("、") || "指定なし"}。${state.extraJP?.trim() ? `備考：${state.extraJP.trim()}。` : ""}`,
+    "超写実的な肌質と布の皺、髪の束感まで忠実に再現。アニメ調・漫画調の表現は禁止。",
+  ]);
+
+  return lines.join("\n");
+};
+
+const buildSoraJSON = (state, EN) => {
+  const face = mergeMulti(state.face, state.faceExtra);
+  const hair = mergeMulti(state.hairStyle, state.hairExtra);
+  const accessories = mergeMulti(
+    (state.accessories || []).filter((item) => item && item !== "no accessories"),
+    state.accessoriesExtra
   );
-}
-
-function buildSoraJSON(state, EN) {
-  const hair = state.hairStyle.filter(Boolean);
-  if (state.hairExtra?.trim()) hair.push(state.hairExtra.trim());
-  const face = state.face.filter(Boolean);
-  if (state.faceExtra?.trim()) face.push(state.faceExtra.trim());
-  const accessories = state.accessories.filter((a) => a && a !== "no accessories");
-  if (state.accessoriesExtra?.trim()) accessories.push(state.accessoriesExtra.trim());
-
-  const bgDetails = state.bgDetails.filter(Boolean);
-  if (state.bgDetailsExtra?.trim()) bgDetails.push(state.bgDetailsExtra.trim());
-
-  const styleArr = state.style.filter(Boolean);
-  if (state.styleExtra?.trim()) styleArr.push(state.styleExtra.trim());
+  const bgDetails = mergeMulti(state.bgDetails, state.bgDetailsExtra);
+  const styleArr = mergeMulti(state.style, state.styleExtra);
+  const renderFinish = mergeMulti(state.renderFinish, state.renderFinishExtra);
+  const cameraMovement = mergeMulti(state.cameraMovement, state.cameraMovementManual);
+  const actions = mergeMulti(state.activity, state.activityManual);
 
   const outfitBase =
     pref(state.dress, state.dressManual) ||
-    `${pref(state.tops, state.topsManual)}, ${pref(state.bottoms, state.bottomsManual)}`;
+    compactSegments([pref(state.tops, state.topsManual), pref(state.bottoms, state.bottomsManual)]).join(", ");
   const outer = pref(state.outer, state.outerManual);
-  const outfit = outer ? `${outfitBase}, with ${outer}` : outfitBase;
-
-  const details = {
-    character: {
-      age: pref(state.age, state.ageManual),
-      gender: pref(state.gender, state.genderManual),
-      ethnicity: pref(state.ethnicity, state.ethnicityManual),
-      face,
-      hair,
-      hair_color: pref(state.hairColor, state.hairColorManual),
-      makeup: pref(state.makeup, state.makeupManual),
-      eye_color: pref(state.eyeColor, state.eyeColorManual),
-      outfit,
-      accessories,
-      fashion_vibe: pref(state.fashionVibe, state.fashionVibeManual),
-    },
-    scene: {
-      background: pref(state.background, state.backgroundManual),
-      background_details: bgDetails,
-      crowd: !!state.crowd,
-      activity: pref(state.activity, state.activityManual),
-    },
-    camera: {
-      shot: pref([state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean).join(", "), state.shotManual),
-      shot_distance: state.shotDistance,
-      shot_angle: state.shotAngle,
-      shot_style: state.shotStyle,
-      shot_manual: state.shotManual,
-      lens: state.lens,
-      focal_length_mm: Number(state.focalLength),
-      depth_of_field: Number(state.dofStrength),
-      aperture: apertureFromDof(state.dofStrength),
-      focus_subject: state.focusSubject,
-      static_camera: !!state.staticCamera,
-      tripod: !!state.tripod,
-      forbid_eye_contact: !!state.forbidEyeContact,
-      candid_mode: state.candidMode,
-    },
-    style: {
-      lighting: pref(state.lighting, state.lightingManual),
-      mood: pref(state.mood, state.moodManual),
-      visual_style: styleArr,
-    },
-  };
+  const outfit = compactSegments([outfitBase, outer ? `with ${outer}` : ""]).join(" ");
 
   return {
     prompt: EN,
-    details,
+    details: {
+      character: {
+        age: pref(state.age, state.ageManual),
+        gender: pref(state.gender, state.genderManual),
+        ethnicity: pref(state.ethnicity, state.ethnicityManual),
+        face,
+        hair,
+        hair_color: pref(state.hairColor, state.hairColorManual),
+        makeup: pref(state.makeup, state.makeupManual),
+        eye_color: pref(state.eyeColor, state.eyeColorManual),
+        outfit,
+        accessories,
+        fashion_vibe: pref(state.fashionVibe, state.fashionVibeManual),
+      },
+      scene: {
+        background: pref(state.background, state.backgroundManual),
+        background_details: bgDetails,
+        crowd: !!state.crowd,
+        activity: actions,
+      },
+      camera: {
+        shot: pref([state.shotDistance, state.shotAngle, state.shotStyle].filter(Boolean).join(", "), state.shotManual),
+        shot_distance: state.shotDistance,
+        shot_angle: state.shotAngle,
+        shot_style: state.shotStyle,
+        shot_manual: state.shotManual,
+        lens: state.lens,
+        focal_length_mm: Number(state.focalLength),
+        depth_of_field: Number(state.dofStrength),
+        aperture: apertureFromDof(state.dofStrength),
+        focus_subject: state.focusSubject,
+        static_camera: !!state.staticCamera,
+        tripod: !!state.tripod,
+        forbid_eye_contact: !!state.forbidEyeContact,
+        candid_mode: state.candidMode,
+        camera_movement: cameraMovement,
+        shutter_speed: pref(state.shutterSpeed, state.shutterManual),
+      },
+      style: {
+        lighting: pref(state.lighting, state.lightingManual),
+        mood: pref(state.mood, state.moodManual),
+        visual_style: styleArr,
+        color_grade: pref(state.colorGrade, state.colorGradeManual),
+      },
+      render: {
+        finish: renderFinish,
+      },
+      controls: {
+        subject_consistency: !!state.subjectConsistency,
+      },
+    },
     metadata: state,
   };
-}
+};
+const randomPick = (arr) => {
+  const pool = Array.isArray(arr) ? arr : [];
+  if (pool.length === 0) return "";
+  const item = pool[Math.floor(Math.random() * pool.length)];
+  return item.en;
+};
 
-// ===== MAIN COMPONENT =====
+const randomSubset = (arr, min = 1, max = 2) => {
+  const pool = Array.isArray(arr) ? [...arr] : [];
+  if (pool.length === 0) return [];
+  const boundedMin = Math.max(0, Math.min(min, pool.length));
+  const boundedMax = Math.max(boundedMin, Math.min(max, pool.length));
+  const count = Math.floor(Math.random() * (boundedMax - boundedMin + 1)) + boundedMin;
+  return pool
+    .sort(() => Math.random() - 0.5)
+    .slice(0, count)
+    .map((item) => item.en);
+};
+
 export default function SoraPromptBuilder({ uiLang = "EN" }) {
   const [state, setState] = useState(defaultState);
-  const [seed, setSeed] = useState(0);
-  const { copy } = useClipboard();
   const [lang, setLang] = useState("EN");
-  const [showPrompt, setShowPrompt] = useState(false);
+  const [showPrompt, setShowPrompt] = useState(true);
+  const [presetOpen, setPresetOpen] = useState(false);
+  const englishRef = useRef(null);
+  const japaneseRef = useRef(null);
+  const { toast, highlightKey, copyWithFeedback } = useCopyFeedback(600);
 
   const EN = useMemo(() => buildEnglishPrompt(state), [state]);
   const JP = useMemo(() => buildJapanesePrompt(state), [state]);
+  const soraJSON = useMemo(() => buildSoraJSON(state, EN), [state, EN]);
+
+  const englishHighlighted = highlightKey === "prompt-en";
+  const japaneseHighlighted = highlightKey === "prompt-jp";
 
   const exportJSON = () => {
-    const soraReady = buildSoraJSON(state, EN);
-    const blob = new Blob([JSON.stringify(soraReady, null, 2)], {
+    const blob = new Blob([JSON.stringify(soraJSON, null, 2)], {
       type: "application/json",
     });
     const url = URL.createObjectURL(blob);
@@ -363,74 +429,84 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
     URL.revokeObjectURL(url);
   };
 
-  function randomPick(arr) { return arr[Math.floor(Math.random() * arr.length)].en; }
-  function randomSubset(arr, min = 1, max = 2) {
-    const n = Math.max(min, Math.min(max, arr.length));
-    const k = Math.floor(Math.random() * (n - min + 1)) + min;
-    const shuffled = [...arr].sort(() => Math.random() - 0.5);
-    return shuffled.slice(0, k).map((i) => i.en);
-  }
-
   const randomize = () => {
-    setSeed((s) => s + 1);
-    const useDress = Math.random() < 0.5;
-    const lens = randomPick(options.cameraLens);
-    const lensMM = parseInt(lens.match(/(\d+)/)?.[1] || "50", 10);
-    setState((prev) => ({
-      ...prev,
-      age: randomPick(options.age),
-      ageManual: "",
-      gender: "female",
-      ethnicity: randomPick(options.ethnicity),
-      ethnicityManual: "",
-      face: randomSubset(options.face, 1, 3),
-      faceExtra: "",
-      hairStyle: randomSubset(options.hairStyle, 1, 3),
-      hairExtra: "",
-      hairColor: randomPick(options.hairColor),
-      hairColorManual: "",
-      makeup: randomPick(options.makeup),
-      makeupManual: "",
-      eyeColor: randomPick(options.eyeColor),
-      eyeColorManual: "",
-      dress: useDress ? randomPick(options.fashionDresses) : "",
-      dressManual: "",
-      tops: useDress ? "" : randomPick(options.tops),
-      topsManual: "",
-      bottoms: useDress ? "" : randomPick(options.bottoms),
-      bottomsManual: "",
-      outer: randomPick(options.outer),
-      outerManual: "",
-      accessories: randomSubset(options.accessories, 1, 2),
-      accessoriesExtra: "",
-      fashionVibe: randomPick(options.fashionVibes),
-      fashionVibeManual: "",
-      background: randomPick(options.background),
-      backgroundManual: "",
-      bgDetails: randomSubset(options.bgDetails, 1, 3),
-      bgDetailsExtra: "",
-      crowd: Math.random() < 0.4,
-      activity: randomPick(options.activity),
-      activityManual: "",
-      shotDistance: randomPick(options.shotDistance),
-      shotAngle: randomPick(options.shotAngle),
-      shotStyle: Math.random() < 0.5 ? randomPick(options.shotStyle) : "",
-      shotManual: "",
-      lens,
-      focalLength: lensMM,
-      dofStrength: Math.floor(Math.random() * 80) + 10,
-      focusSubject: ["eyes", "eyelashes", "face", "hands", "book"][Math.floor(Math.random() * 5)],
-      lighting: randomPick(options.lighting),
-      lightingManual: "",
-      mood: randomPick(options.mood),
-      moodManual: "",
-      style: randomSubset(options.style, 1, 2),
-      styleExtra: "",
-      // keep candid/static settings as-is so UX remains predictable
-    }));
+    setState((prev) => {
+      const base = defaultState();
+      const useDress = Math.random() < 0.5;
+      const lens = randomPick(options.cameraLens);
+      const lensMM = parseInt(lens.match(/(\d+)/)?.[1] || "50", 10);
+      const accessoryPool = options.accessories.filter((opt) => opt.en !== "no accessories");
+      return {
+        ...base,
+        staticCamera: prev.staticCamera,
+        tripod: prev.tripod,
+        forbidEyeContact: prev.forbidEyeContact,
+        candidMode: prev.candidMode,
+        subjectConsistency: prev.subjectConsistency,
+        age: randomPick(options.age),
+        ageManual: "",
+        gender: "female",
+        genderManual: "",
+        ethnicity: randomPick(options.ethnicity),
+        ethnicityManual: "",
+        face: randomSubset(options.face, 1, 3),
+        faceExtra: "",
+        hairStyle: randomSubset(options.hairStyle, 1, 3),
+        hairExtra: "",
+        hairColor: randomPick(options.hairColor),
+        hairColorManual: "",
+        makeup: randomPick(options.makeup),
+        makeupManual: "",
+        eyeColor: randomPick(options.eyeColor),
+        eyeColorManual: "",
+        dress: useDress ? randomPick(options.fashionDresses) : "",
+        dressManual: "",
+        tops: useDress ? "" : randomPick(options.tops),
+        topsManual: "",
+        bottoms: useDress ? "" : randomPick(options.bottoms),
+        bottomsManual: "",
+        outer: randomPick(options.outer),
+        outerManual: "",
+        accessories: Math.random() < 0.4 ? [] : randomSubset(accessoryPool, 1, 2),
+        accessoriesExtra: "",
+        fashionVibe: randomPick(options.fashionVibes),
+        fashionVibeManual: "",
+        background: randomPick(options.background),
+        backgroundManual: "",
+        bgDetails: randomSubset(options.bgDetails, 1, 3),
+        bgDetailsExtra: "",
+        crowd: Math.random() < 0.35,
+        activity: randomSubset(options.activity, 1, 2),
+        activityManual: "",
+        shotDistance: randomPick(options.shotDistance),
+        shotAngle: randomPick(options.shotAngle),
+        shotStyle: Math.random() < 0.5 ? randomPick(options.shotStyle) : "",
+        shotManual: "",
+        lens,
+        focalLength: lensMM,
+        dofStrength: Math.floor(Math.random() * 80) + 10,
+        focusSubject: ["eyes", "face", "hands", "book", "subject"][Math.floor(Math.random() * 5)],
+        cameraMovement: randomSubset(options.cameraMovement, 1, 2),
+        cameraMovementManual: "",
+        shutterSpeed: randomPick(options.shutterSpeed),
+        shutterManual: "",
+        colorGrade: randomPick(options.colorGrade),
+        colorGradeManual: "",
+        renderFinish: randomSubset(options.renderFinish, 1, 2),
+        renderFinishExtra: "",
+        lighting: randomPick(options.lighting),
+        lightingManual: "",
+        mood: randomPick(options.mood),
+        moodManual: "",
+        style: randomSubset(options.style, 2, 3),
+        styleExtra: "",
+        extraEN: "",
+        extraJP: "",
+      };
+    });
   };
 
-  const reset = () => setState(defaultState);
+  const reset = () => setState(defaultState());
 
   const field = (label, node, hint) => (
     <div className="space-y-1">
@@ -440,24 +516,29 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
     </div>
   );
 
-  const multiPills = (values, setValues, pool) => (
+  const multiPills = (values, setValues, pool, { min = 0, max } = {}) => (
     <div className="flex flex-wrap gap-2">
-      <button
-        key="__none"
-        onClick={() => setValues([])}
-        className="sr-only"
-        aria-label={uiLang === "JP" ? "すべて解除" : "Clear all selections"}
-      />
       {pool.map((opt) => {
         const active = values.includes(opt.en);
+        const disabled = !active && typeof max === "number" && values.length >= max;
         return (
           <button
+            type="button"
             key={opt.en}
-            onClick={() =>
-              setValues(active ? values.filter((v) => v !== opt.en) : [...values, opt.en])
-            }
-            className={`px-2.5 py-1 rounded-full text-xs border ${
-              active ? "bg-black text-white border-black" : "bg-white text-gray-700 border-gray-300"
+            disabled={disabled}
+            onClick={() => {
+              if (active) {
+                setValues(values.filter((v) => v !== opt.en));
+              } else if (!disabled) {
+                setValues([...values, opt.en]);
+              }
+            }}
+            className={`px-2.5 py-1 rounded-full text-xs border transition ${
+              active
+                ? "bg-black text-white border-black"
+                : disabled
+                ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                : "bg-white text-gray-700 border-gray-300 hover:border-black"
             }`}
           >
             {uiLang === "JP" ? opt.jp : opt.en}
@@ -467,172 +548,370 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
     </div>
   );
 
+  const copyEnglish = () => {
+    const exec = () =>
+      copyWithFeedback(EN, {
+        element: englishRef,
+        label: "English copied",
+        failLabel: "Copy failed",
+      });
+    if (lang !== "EN" && typeof window !== "undefined") {
+      setLang("EN");
+      window.requestAnimationFrame(exec);
+    } else {
+      exec();
+    }
+  };
+
+  const copyJapanese = () => {
+    const exec = () =>
+      copyWithFeedback(JP, {
+        element: japaneseRef,
+        label: "日本語コピー",
+        failLabel: "コピー失敗",
+      });
+    if (lang !== "JP" && typeof window !== "undefined") {
+      setLang("JP");
+      window.requestAnimationFrame(exec);
+    } else {
+      exec();
+    }
+  };
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
-      <header className="sticky top-0 z-20 bg-white/80 backdrop-blur border-b">
+    <div className="min-h-screen bg-gray-50 text-gray-900 pb-28">
+      <PresetManager
+        open={presetOpen}
+        onClose={() => setPresetOpen(false)}
+        storageKey="sora-presets-v2"
+        currentState={state}
+        onApply={(next) => setState(cloneState(next))}
+        transformSave={cloneState}
+        transformLoad={cloneState}
+        title="Sora Presets"
+      />
+
+      <FloatingToast message={toast} />
+
+      <header className="sticky top-0 z-20 bg-white/90 backdrop-blur border-b">
         <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Wand2 className="h-5 w-5" />
-            <h1 className="text-base sm:text-lg font-semibold">Sora Prompt Builder — EN/JP</h1>
+            <div>
+              <h1 className="text-base sm:text-lg font-semibold">Sora Prompt Builder — EN/JP</h1>
+              <p className="text-xs text-gray-500">
+                Structured slots keep subject → location → camera → light → mood → quality → render order.
+              </p>
+            </div>
           </div>
           <div className="flex items-center gap-2">
-            <Button onClick={randomize} title="Randomize"><Shuffle className="h-4 w-4" />Random</Button>
-            <Button variant="subtle" onClick={reset} title="Reset"><RotateCcw className="h-4 w-4" />Reset</Button>
+            <Button onClick={randomize} title="Randomize selections">
+              <Shuffle className="h-4 w-4" />
+              Random
+            </Button>
+            <Button variant="subtle" onClick={reset} title="Reset to defaults">
+              <RotateCcw className="h-4 w-4" />
+              Reset
+            </Button>
           </div>
         </div>
       </header>
 
-      <main className="max-w-6xl mx-auto px-4 pt-6 pb-32 grid grid-cols-1 xl:grid-cols-3 gap-6 items-start">
-        {/* LEFT: Controls */}
+      <main className="max-w-6xl mx-auto px-4 pt-6 grid grid-cols-1 xl:grid-cols-3 gap-6 items-start">
         <div className="xl:col-span-2 space-y-6">
-          {/* Character */}
-            <Card>
-              <CardHeader title="Character" subtitle="Fine-grained controls - add freckles, moles, dimples, etc." />
+          <Card>
+            <CardHeader title="Subject" subtitle="Identity, facial detail, hair, wardrobe, and vibe." />
             <CardContent className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {field("Age", (
+              {field(
+                "Age",
                 <div className="space-y-2">
                   <Select
                     value={state.age}
                     onChange={(v) => setState({ ...state, age: v })}
                     options={toSelectOptions(options.age, uiLang)}
                   />
-                  <Input value={state.ageManual} onChange={(v) => setState({ ...state, ageManual: v })} placeholder="e.g. early 20s" />
+                  <Input
+                    value={state.ageManual}
+                    onChange={(v) => setState({ ...state, ageManual: v })}
+                    placeholder="e.g. early 20s"
+                  />
                 </div>
-              ))}
-              {field("Ethnicity / Vibe", (
-                <div className="space-y-2">
-                  <Select value={state.ethnicity} onChange={(v) => setState({ ...state, ethnicity: v })} options={toSelectOptions(options.ethnicity, uiLang)} />
-                  <Input value={state.ethnicityManual} onChange={(v) => setState({ ...state, ethnicityManual: v })} placeholder="e.g. Japanese-Taiwanese vibe" />
-                </div>
-              ))}
-
-              {field("Face (multi)", (
-                <div className="space-y-2">
-                  {multiPills(state.face, (vals) => setState({ ...state, face: vals }), options.face)}
-                  <Input value={state.faceExtra} onChange={(v) => setState({ ...state, faceExtra: v })} placeholder="e.g. tiny beauty mark above lip" />
-                </div>
-              ), "Add freckles, moles, dimples, etc." )}
-
-              {field("Hair (multi)", (
-                <div className="space-y-2">
-                  {multiPills(state.hairStyle, (vals) => setState({ ...state, hairStyle: vals }), options.hairStyle)}
-                  <Input value={state.hairExtra} onChange={(v) => setState({ ...state, hairExtra: v })} placeholder="e.g. loose strands, tucked behind ear" />
-                </div>
-              ))}
-
-              {field("Hair color", (
-                <div className="space-y-2">
-                  <Select value={state.hairColor} onChange={(v) => setState({ ...state, hairColor: v })} options={toSelectOptions(options.hairColor, uiLang)} />
-                  <Input value={state.hairColorManual} onChange={(v) => setState({ ...state, hairColorManual: v })} placeholder="e.g. ash brown" />
-                </div>
-              ))}
-
-              {field("Makeup", (
-                <div className="space-y-2">
-                  <Select value={state.makeup} onChange={(v) => setState({ ...state, makeup: v })} options={toSelectOptions(options.makeup, uiLang)} />
-                  <Input value={state.makeupManual} onChange={(v) => setState({ ...state, makeupManual: v })} placeholder="e.g. natural base, subtle eyeliner" />
-                </div>
-              ))}
-
-              {field("Eye color", (
-                <div className="space-y-2">
-                  <Select value={state.eyeColor} onChange={(v) => setState({ ...state, eyeColor: v })} options={toSelectOptions(options.eyeColor, uiLang)} />
-                  <Input value={state.eyeColorManual} onChange={(v) => setState({ ...state, eyeColorManual: v })} placeholder="e.g. deep umber" />
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-
-          {/* Outfit */}
-          <Card>
-            <CardHeader title="Outfit" subtitle="Clothing & accessories. Each field allows manual override - custom text supported." />
-            <CardContent className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {field("Tops", (
-                <div className="space-y-2">
-                  <Select value={state.tops} onChange={(v) => setState({ ...state, tops: v })} options={toSelectOptions(options.tops, uiLang)} />
-                  <Input value={state.topsManual} onChange={(v) => setState({ ...state, topsManual: v })} placeholder="e.g. silky blouse with a deep V-neckline (subtle)" />
-                </div>
-              ))}
-              {field("Bottoms", (
-                <div className="space-y-2">
-                  <Select value={state.bottoms} onChange={(v) => setState({ ...state, bottoms: v })} options={toSelectOptions(options.bottoms, uiLang)} />
-                  <Input value={state.bottomsManual} onChange={(v) => setState({ ...state, bottomsManual: v })} placeholder="e.g. sleek high-waist mini skirt / tapered trousers" />
-                </div>
-              ))}
-              {field("Dress", (
+              )}
+              {field(
+                "Gender",
                 <div className="space-y-2">
                   <Select
-                    value={state.dress}
-                    onChange={(v) => setState({ ...state, dress: v })}
-                    options={toSelectOptions(options.fashionDresses, uiLang)}
+                    value={state.gender}
+                    onChange={(v) => setState({ ...state, gender: v })}
+                    options={toSelectOptions(options.gender, uiLang)}
                   />
                   <Input
-                    value={state.dressManual}
-                    onChange={(v) => setState({ ...state, dressManual: v })}
-                    placeholder="e.g. floral midi dress"
+                    value={state.genderManual}
+                    onChange={(v) => setState({ ...state, genderManual: v })}
+                    placeholder="Custom expression"
                   />
                 </div>
-              ))}
-              {field("Outer", (
+              )}
+              {field(
+                "Ethnicity / Vibe",
                 <div className="space-y-2">
-                  <Select value={state.outer} onChange={(v) => setState({ ...state, outer: v })} options={toSelectOptions(options.outer, uiLang)} />
-                  <Input value={state.outerManual} onChange={(v) => setState({ ...state, outerManual: v })} placeholder="e.g. none / cardigan / blazer" />
+                  <Select
+                    value={state.ethnicity}
+                    onChange={(v) => setState({ ...state, ethnicity: v })}
+                    options={toSelectOptions(options.ethnicity, uiLang)}
+                  />
+                  <Input
+                    value={state.ethnicityManual}
+                    onChange={(v) => setState({ ...state, ethnicityManual: v })}
+                    placeholder="e.g. Japanese-Taiwanese vibe"
+                  />
                 </div>
-              ))}
-              {field("Accessories (multi)", (
+              )}
+              {field(
+                "Face (multi)",
                 <div className="space-y-2">
-                  {multiPills(state.accessories, (vals) => setState({ ...state, accessories: vals }), options.accessories)}
-                  <Input value={state.accessoriesExtra} onChange={(v) => setState({ ...state, accessoriesExtra: v })} placeholder="e.g. silver ring, hair tie" />
-                </div>
-              ))}
-              {field("Fashion vibe", (
+                  {multiPills(state.face, (vals) => setState({ ...state, face: vals }), options.face, { max: 4 })}
+                  <Input
+                    value={state.faceExtra}
+                    onChange={(v) => setState({ ...state, faceExtra: v })}
+                    placeholder="Manual descriptors"
+                  />
+                </div>,
+                "Freckles, dimples, beauty marks, bone structure."
+              )}
+              {field(
+                "Hair (multi)",
                 <div className="space-y-2">
-                  <Select value={state.fashionVibe} onChange={(v) => setState({ ...state, fashionVibe: v })} options={toSelectOptions(options.fashionVibes, uiLang)} />
-                  <Input value={state.fashionVibeManual} onChange={(v) => setState({ ...state, fashionVibeManual: v })} placeholder="e.g. urban casual chic" />
+                  {multiPills(state.hairStyle, (vals) => setState({ ...state, hairStyle: vals }), options.hairStyle, { max: 4 })}
+                  <Input
+                    value={state.hairExtra}
+                    onChange={(v) => setState({ ...state, hairExtra: v })}
+                    placeholder="Manual hair notes"
+                  />
                 </div>
-              ))}
+              )}
+              {field(
+                "Hair color",
+                <div className="space-y-2">
+                  <Select
+                    value={state.hairColor}
+                    onChange={(v) => setState({ ...state, hairColor: v })}
+                    options={toSelectOptions(options.hairColor, uiLang)}
+                  />
+                  <Input
+                    value={state.hairColorManual}
+                    onChange={(v) => setState({ ...state, hairColorManual: v })}
+                    placeholder="e.g. honey brown ombré"
+                  />
+                </div>
+              )}
+              {field(
+                "Makeup",
+                <div className="space-y-2">
+                  <Select
+                    value={state.makeup}
+                    onChange={(v) => setState({ ...state, makeup: v })}
+                    options={toSelectOptions(options.makeup, uiLang)}
+                  />
+                  <Input
+                    value={state.makeupManual}
+                    onChange={(v) => setState({ ...state, makeupManual: v })}
+                    placeholder="e.g. soft matte skin, glossy lip"
+                  />
+                </div>
+              )}
+              {field(
+                "Eye color",
+                <div className="space-y-2">
+                  <Select
+                    value={state.eyeColor}
+                    onChange={(v) => setState({ ...state, eyeColor: v })}
+                    options={toSelectOptions(options.eyeColor, uiLang)}
+                  />
+                  <Input
+                    value={state.eyeColorManual}
+                    onChange={(v) => setState({ ...state, eyeColorManual: v })}
+                    placeholder="e.g. warm hazel"
+                  />
+                </div>
+              )}
+              {field(
+                "Outfit",
+                <div className="space-y-2">
+                  <Input
+                    value={state.dress}
+                    onChange={(v) => setState({ ...state, dress: v })}
+                    placeholder="Dress (optional)"
+                  />
+                  <Input
+                    value={state.tops}
+                    onChange={(v) => setState({ ...state, tops: v })}
+                    placeholder="Top"
+                  />
+                  <Input
+                    value={state.bottoms}
+                    onChange={(v) => setState({ ...state, bottoms: v })}
+                    placeholder="Bottom"
+                  />
+                  <Input
+                    value={state.outer}
+                    onChange={(v) => setState({ ...state, outer: v })}
+                    placeholder="Outerwear"
+                  />
+                </div>,
+                "Populate dress OR top/bottom + optional outer."
+              )}
+              {field(
+                "Accessories",
+                <div className="space-y-2">
+                  {multiPills(state.accessories, (vals) => setState({ ...state, accessories: vals }), options.accessories, {
+                    max: 3,
+                  })}
+                  <Input
+                    value={state.accessoriesExtra}
+                    onChange={(v) => setState({ ...state, accessoriesExtra: v })}
+                    placeholder="Manual accessories"
+                  />
+                </div>
+              )}
+              {field(
+                "Fashion vibe",
+                <div className="space-y-2">
+                  <Select
+                    value={state.fashionVibe}
+                    onChange={(v) => setState({ ...state, fashionVibe: v })}
+                    options={toSelectOptions(options.fashionVibes, uiLang)}
+                  />
+                  <Input
+                    value={state.fashionVibeManual}
+                    onChange={(v) => setState({ ...state, fashionVibeManual: v })}
+                    placeholder="Manual vibe"
+                  />
+                </div>
+              )}
             </CardContent>
           </Card>
 
-          {/* Scene */}
           <Card>
-            <CardHeader title="Scene" subtitle="Background, details, and whether to include passersby." />
+            <CardHeader title="Location" subtitle="Background, details, and crowd control." />
             <CardContent className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {field("Background", (
+              {field(
+                "Backdrop",
                 <div className="space-y-2">
-                  <Select value={state.background} onChange={(v) => setState({ ...state, background: v })} options={toSelectOptions(options.background, uiLang)} />
-                  <Input value={state.backgroundManual} onChange={(v) => setState({ ...state, backgroundManual: v })} placeholder="e.g. large window with city lights" />
+                  <Select
+                    value={state.background}
+                    onChange={(v) => setState({ ...state, background: v })}
+                    options={toSelectOptions(options.background, uiLang)}
+                  />
+                  <Input
+                    value={state.backgroundManual}
+                    onChange={(v) => setState({ ...state, backgroundManual: v })}
+                    placeholder="Manual location"
+                  />
                 </div>
-              ))}
-              {field("Background details (multi)", (
+              )}
+              {field(
+                "Background details",
                 <div className="space-y-2">
-                  {multiPills(state.bgDetails, (vals) => setState({ ...state, bgDetails: vals }), options.bgDetails)}
-                  <Input value={state.bgDetailsExtra} onChange={(v) => setState({ ...state, bgDetailsExtra: v })} placeholder="e.g. scattered sticky notes, ceramic mug" />
+                  {multiPills(state.bgDetails, (vals) => setState({ ...state, bgDetails: vals }), options.bgDetails, {
+                    max: 4,
+                  })}
+                  <Input
+                    value={state.bgDetailsExtra}
+                    onChange={(v) => setState({ ...state, bgDetailsExtra: v })}
+                    placeholder="Manual props"
+                  />
                 </div>
-              ))}
-              <div className="flex items-end"><Toggle checked={state.crowd} onChange={(v) => setState({ ...state, crowd: v })} label="Include background people / passersby" /></div>
+              )}
+              <div className="flex items-end">
+                <Toggle
+                  checked={state.crowd}
+                  onChange={(v) => setState({ ...state, crowd: v })}
+                  label="Include background passersby"
+                />
+              </div>
             </CardContent>
           </Card>
 
-          {/* Action */}
           <Card>
-            <CardHeader title="Action" subtitle="What the subject is doing - choose from options or enter manually." />
+            <CardHeader title="Action & Movement" subtitle="Subject action plus dedicated camera movement slot." />
             <CardContent className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {field("Activity", (
+              {field(
+                "Subject action",
                 <div className="space-y-2">
-                  <Select value={state.activity} onChange={(v) => setState({ ...state, activity: v })} options={toSelectOptions(options.activity, uiLang)} />
-                  <Input value={state.activityManual} onChange={(v) => setState({ ...state, activityManual: v })} placeholder="e.g. organizing study notes, highlighting text" />
-                </div>
-              ))}
+                  {multiPills(state.activity, (vals) => setState({ ...state, activity: vals }), options.activity, { max: 3 })}
+                  <Input
+                    value={state.activityManual}
+                    onChange={(v) => setState({ ...state, activityManual: v })}
+                    placeholder="Manual action"
+                  />
+                </div>,
+                "Keep motion verbs consistent for video clips."
+              )}
+              {field(
+                "Camera movement",
+                <div className="space-y-2">
+                  {multiPills(
+                    state.cameraMovement,
+                    (vals) => setState({ ...state, cameraMovement: vals }),
+                    options.cameraMovement,
+                    { max: 2 }
+                  )}
+                  <Input
+                    value={state.cameraMovementManual}
+                    onChange={(v) => setState({ ...state, cameraMovementManual: v })}
+                    placeholder="Manual move notes"
+                  />
+                </div>,
+                "Separate from subject action for clarity."
+              )}
+              <div className="flex flex-col gap-3">
+                <Toggle
+                  checked={state.staticCamera}
+                  onChange={(v) => setState({ ...state, staticCamera: v })}
+                  label="Static locked camera"
+                />
+                <Toggle
+                  checked={state.tripod}
+                  onChange={(v) => setState({ ...state, tripod: v })}
+                  label="Tripod stabilised"
+                />
+                <Toggle
+                  checked={state.forbidEyeContact}
+                  onChange={(v) => setState({ ...state, forbidEyeContact: v })}
+                  label={
+                    <span className="inline-flex items-center gap-1">
+                      <EyeOff className="h-3.5 w-3.5" />
+                      Forbid direct eye contact
+                    </span>
+                  }
+                />
+              </div>
+              {field(
+                "Candid mode",
+                <Select
+                  value={state.candidMode}
+                  onChange={(v) => setState({ ...state, candidMode: v })}
+                  options={[
+                    { value: "none", label: "none" },
+                    { value: "far", label: "far documentary" },
+                    { value: "close", label: "close proximity" },
+                  ]}
+                />,
+                "Document how aware the subject feels."
+              )}
             </CardContent>
           </Card>
 
-          {/* Camera */}
           <Card>
-            <CardHeader title="Camera" subtitle="Shot, focal length, depth-of-field, and movement or candid controls." right={<CameraOff className="h-5 w-5 text-gray-500" />} />
+            <CardHeader
+              title="Camera"
+              subtitle="Shot, lens, depth of field, and shutter"
+              right={<CameraOff className="h-5 w-5 text-gray-500" />}
+            />
             <CardContent className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {field("Shot", (
+              {field(
+                "Shot composition",
                 <div className="space-y-2">
                   <Select
                     value={state.shotDistance}
@@ -652,11 +931,12 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
                   <Input
                     value={state.shotManual}
                     onChange={(v) => setState({ ...state, shotManual: v })}
-                    placeholder="e.g. Dutch angle, tracking shot"
+                    placeholder="Manual shot notes"
                   />
                 </div>
-              ))}
-              {field("Lens", (
+              )}
+              {field(
+                "Lens",
                 <Select
                   value={state.lens}
                   onChange={(v) => {
@@ -665,157 +945,261 @@ export default function SoraPromptBuilder({ uiLang = "EN" }) {
                   }}
                   options={toSelectOptions(options.cameraLens, uiLang)}
                 />
-              ))}
-              {field("Focal length (mm)", (
-                <Input type="number" value={state.focalLength} onChange={(v) => setState({ ...state, focalLength: v })} min={18} max={135} step={1} />
-              ), "Typical portrait: 50–85mm" )}
-              {field("Depth of field (0–100)", (
-                <Input type="number" value={state.dofStrength} onChange={(v) => setState({ ...state, dofStrength: Math.max(0, Math.min(100, v)) })} min={0} max={100} step={1} />
-              ), "Higher = deeper focus - mapped to aperture" )}
-              {field("Focus subject (manual)", (
-                <Input value={state.focusSubject} onChange={(v) => setState({ ...state, focusSubject: v })} placeholder="e.g. eyes / eyelashes / face / hands / book" />
-              ))}
-              {/* Movement toggles */}
-              <div className="flex flex-col gap-3">
-                <Toggle checked={state.staticCamera} onChange={(v) => setState({ ...state, staticCamera: v })} label="Static camera - no zoom or pan" />
-                <Toggle checked={state.tripod} onChange={(v) => setState({ ...state, tripod: v })} label="Locked-off tripod - no handheld shake" />
-                <Toggle checked={state.forbidEyeContact} onChange={(v) => setState({ ...state, forbidEyeContact: v })} label={<span className="inline-flex items-center gap-1"><EyeOff className="h-3.5 w-3.5"/>Forbid direct eye contact</span>} />
-              </div>
-              {/* Candid selector */}
-              {field("Candid mode", (
-                <Select
-                  value={state.candidMode}
-                  onChange={(v) => setState({ ...state, candidMode: v })}
-                  options={[
-                    { value: "none", label: "none" },
-                    { value: "far", label: "far - documentary observe" },
-                    { value: "close", label: "close - peeking proximity" },
-                  ]}
+              )}
+              {field(
+                "Focal length (mm)",
+                <Input
+                  type="number"
+                  value={state.focalLength}
+                  onChange={(v) => setState({ ...state, focalLength: v })}
+                  min={8}
+                  max={200}
+                  step={1}
+                />,
+                "Typical portrait: 50-85mm"
+              )}
+              {field(
+                "Depth of field (0-100)",
+                <Input
+                  type="number"
+                  value={state.dofStrength}
+                  onChange={(v) => setState({ ...state, dofStrength: Math.max(0, Math.min(100, v)) })}
+                  min={0}
+                  max={100}
+                  step={1}
+                />,
+                "Higher values = deeper focus"
+              )}
+              {field(
+                "Focus subject",
+                <Input
+                  value={state.focusSubject}
+                  onChange={(v) => setState({ ...state, focusSubject: v })}
+                  placeholder="e.g. eyes / hands / object"
                 />
-              ), "Choose how unaware is conveyed." )}
+              )}
+              {field(
+                "Shutter",
+                <div className="space-y-2">
+                  <Select
+                    value={state.shutterSpeed}
+                    onChange={(v) => setState({ ...state, shutterSpeed: v })}
+                    options={toSelectOptions(options.shutterSpeed, uiLang)}
+                  />
+                  <Input
+                    value={state.shutterManual}
+                    onChange={(v) => setState({ ...state, shutterManual: v })}
+                    placeholder="Manual shutter notes"
+                  />
+                </div>
+              )}
             </CardContent>
           </Card>
 
-          {/* Lighting & Mood */}
           <Card>
-            <CardHeader title="Lighting / Mood / Style" subtitle="Cinematic feel without a color palette field." />
+            <CardHeader title="Lighting & Mood" subtitle="Light design and emotional tone." />
             <CardContent className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {field("Lighting", (
+              {field(
+                "Lighting",
                 <div className="space-y-2">
-                  <Select value={state.lighting} onChange={(v) => setState({ ...state, lighting: v })} options={toSelectOptions(options.lighting, uiLang)} />
-                  <Input value={state.lightingManual} onChange={(v) => setState({ ...state, lightingManual: v })} placeholder="e.g. soft lamp + faint neon spill" />
+                  <Select
+                    value={state.lighting}
+                    onChange={(v) => setState({ ...state, lighting: v })}
+                    options={toSelectOptions(options.lighting, uiLang)}
+                  />
+                  <Input
+                    value={state.lightingManual}
+                    onChange={(v) => setState({ ...state, lightingManual: v })}
+                    placeholder="Manual lighting"
+                  />
                 </div>
-              ))}
-              {field("Mood", (
+              )}
+              {field(
+                "Mood",
                 <div className="space-y-2">
-                  <Select value={state.mood} onChange={(v) => setState({ ...state, mood: v })} options={toSelectOptions(options.mood, uiLang)} />
-                  <Input value={state.moodManual} onChange={(v) => setState({ ...state, moodManual: v })} placeholder="e.g. serene, quietly determined" />
+                  <Select
+                    value={state.mood}
+                    onChange={(v) => setState({ ...state, mood: v })}
+                    options={toSelectOptions(options.mood, uiLang)}
+                  />
+                  <Input
+                    value={state.moodManual}
+                    onChange={(v) => setState({ ...state, moodManual: v })}
+                    placeholder="Manual mood"
+                  />
                 </div>
-              ))}
-              {field("Style (multi)", (
+              )}
+              {field(
+                "Color grade",
                 <div className="space-y-2">
-                  {multiPills(state.style, (vals) => setState({ ...state, style: vals }), options.style)}
-                  <Input value={state.styleExtra} onChange={(v) => setState({ ...state, styleExtra: v })} placeholder="e.g. subtle film grain, zero bloom" />
+                  <Select
+                    value={state.colorGrade}
+                    onChange={(v) => setState({ ...state, colorGrade: v })}
+                    options={toSelectOptions(options.colorGrade, uiLang)}
+                  />
+                  <Input
+                    value={state.colorGradeManual}
+                    onChange={(v) => setState({ ...state, colorGradeManual: v })}
+                    placeholder="Manual grade"
+                  />
                 </div>
-              ))}
+              )}
             </CardContent>
           </Card>
 
-          {/* Output Notes */}
           <Card>
-            <CardHeader title="Notes" subtitle="Free-form notes for both languages." />
+            <CardHeader title="Style & Render" subtitle="Visual treatments, render finish, and consistency toggle." />
+            <CardContent className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {field(
+                "Style",
+                <div className="space-y-2">
+                  {multiPills(state.style, (vals) => setState({ ...state, style: vals }), options.style, { max: 4 })}
+                  <Input
+                    value={state.styleExtra}
+                    onChange={(v) => setState({ ...state, styleExtra: v })}
+                    placeholder="Manual style"
+                  />
+                </div>
+              )}
+              {field(
+                "Render finish",
+                <div className="space-y-2">
+                  {multiPills(
+                    state.renderFinish,
+                    (vals) => setState({ ...state, renderFinish: vals }),
+                    options.renderFinish,
+                    { max: 3 }
+                  )}
+                  <Input
+                    value={state.renderFinishExtra}
+                    onChange={(v) => setState({ ...state, renderFinishExtra: v })}
+                    placeholder="Manual render notes"
+                  />
+                </div>
+              )}
+              <div className="flex items-end">
+                <Toggle
+                  checked={state.subjectConsistency}
+                  onChange={(v) => setState({ ...state, subjectConsistency: v })}
+                  label="Maintain subject consistency (remix safe)"
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader title="Notes" subtitle="Free-form additions." />
             <CardContent className="grid sm:grid-cols-2 gap-4">
-              {field("Extra EN - manual", (
-                <Textarea value={state.extraEN} onChange={(v) => setState({ ...state, extraEN: v })} placeholder="Any extra English notes - e.g. light film grain, no bloom" rows={3} />
-              ))}
-              {field("追記 JP - マニュアル", (
-                <Textarea value={state.extraJP} onChange={(v) => setState({ ...state, extraJP: v })} placeholder="日本語での追記事項 - 例: 微かなフィルムグレイン、ブルームなし" rows={3} />
-              ))}
+              <Textarea
+                value={state.extraEN}
+                onChange={(v) => setState({ ...state, extraEN: v })}
+                placeholder="Extra English notes"
+                rows={4}
+              />
+              <Textarea
+                value={state.extraJP}
+                onChange={(v) => setState({ ...state, extraJP: v })}
+                placeholder="日本語での追記"
+                rows={4}
+              />
             </CardContent>
           </Card>
         </div>
 
-        {/* RIGHT: Outputs */}
         <div className="space-y-6">
-          {showPrompt && (
-            <Card className="fixed bottom-16 left-0 right-0 bg-white z-10">
+          {showPrompt ? (
+            <Card>
               <CardHeader
                 title={lang === "EN" ? "English Prompt" : "日本語プロンプト"}
-                subtitle={
-                  lang === "EN"
-                    ? "Natural prose for Sora - copy-ready."
-                    : "英語と別でコピペしやすいよう分離。辞書ベースでオフライン生成。"
-                }
+                subtitle="Auto-optimised grammar & slot order"
                 right={
-                  <div className="flex gap-2">
-                    <Button
-                      variant={lang === "EN" ? "default" : "subtle"}
-                      onClick={() => setLang("EN")}
-                    >
+                  <div className="flex items-center gap-2">
+                    <Button variant={lang === "EN" ? "default" : "subtle"} onClick={() => setLang("EN")}>
                       EN
                     </Button>
-                    <Button
-                      variant={lang === "JP" ? "default" : "subtle"}
-                      onClick={() => setLang("JP")}
-                    >
+                    <Button variant={lang === "JP" ? "default" : "subtle"} onClick={() => setLang("JP")}>
                       JP
+                    </Button>
+                    <Button variant="ghost" onClick={() => setShowPrompt(false)} title="Hide prompt panel">
+                      Hide
                     </Button>
                   </div>
                 }
               />
-              <CardContent>
-                <div className="flex items-center justify-between mb-3">
-                  {lang === "EN" ? (
-                    <div className="text-xs text-gray-500">
-                      Aperture ≈ {apertureFromDof(state.dofStrength)} (from DoF {state.dofStrength})
-                    </div>
-                  ) : (
-                    <div className="flex items-center gap-2 text-xs text-gray-500">
-                      <Languages className="h-4 w-4" />内蔵変換 (機械翻訳API不使用)
-                    </div>
-                  )}
-                  <div className="flex gap-2">
+              <CardContent className="space-y-3">
+                <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-gray-500">
+                  <div>Aperture ≈ {apertureFromDof(state.dofStrength)} (DoF {state.dofStrength})</div>
+                  <div className="flex items-center gap-2">
                     <Button
                       variant="ghost"
                       onClick={() =>
-                        copy(
-                          JSON.stringify(buildSoraJSON(state, EN), null, 2)
-                        )
+                        copyWithFeedback(JSON.stringify(soraJSON, null, 2), {
+                          label: "JSON copied",
+                        })
                       }
                       title="Copy JSON"
                     >
-                      <Copy className="h-4 w-4" />
-                      {lang === "EN" ? "Copy JSON" : "JSONコピー"}
+                      <Copy className="h-4 w-4" /> JSON
                     </Button>
-                    <Button
-                      variant="ghost"
-                      onClick={exportJSON}
-                      title="Export JSON"
-                    >
+                    <Button variant="ghost" onClick={exportJSON} title="Export JSON">
                       <Download className="h-4 w-4" />
                       Export
                     </Button>
                   </div>
                 </div>
-                <Textarea value={lang === "EN" ? EN : JP} onChange={() => {}} rows={14} className="font-mono" />
+                <div className="relative space-y-0">
+                  <Textarea
+                    value={EN}
+                    onChange={() => {}}
+                    readOnly
+                    rows={14}
+                    inputRef={englishRef}
+                    highlight={englishHighlighted && lang === "EN"}
+                    highlightKey="prompt-en"
+                    className={`font-mono transition-opacity ${
+                      lang === "EN" ? "opacity-100" : "opacity-0 pointer-events-none absolute inset-0"
+                    }`}
+                  />
+                  <Textarea
+                    value={JP}
+                    onChange={() => {}}
+                    readOnly
+                    rows={16}
+                    inputRef={japaneseRef}
+                    highlight={japaneseHighlighted && lang === "JP"}
+                    highlightKey="prompt-jp"
+                    className={`font-mono transition-opacity ${
+                      lang === "JP" ? "opacity-100" : "opacity-0 pointer-events-none absolute inset-0"
+                    }`}
+                  />
+                </div>
               </CardContent>
             </Card>
+          ) : (
+            <Button variant="subtle" onClick={() => setShowPrompt(true)}>
+              Show prompt panel
+            </Button>
           )}
         </div>
       </main>
 
-      <Button
-        className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-20"
-        onClick={() => setShowPrompt((p) => !p)}
-      >
-        {showPrompt ? "Hide Prompt" : "Show Prompt"}
-      </Button>
-
-      <footer className="max-w-6xl mx-auto px-4 pb-10 text-xs text-gray-500">
-        <p>
-          Notes: This builder includes static camera, candid modes (far or close), forbid-eye-contact, and continuous-action emphasis. All ASCII punctuation to avoid parser errors.
-        </p>
-      </footer>
+      <ActionBar>
+        <Button onClick={copyEnglish}>
+          <Copy className="h-4 w-4" /> EN
+        </Button>
+        <Button onClick={copyJapanese}>
+          <Languages className="h-4 w-4" /> JP
+        </Button>
+        <Button variant="subtle" onClick={() => setPresetOpen(true)}>
+          <Layers className="h-4 w-4" /> Presets
+        </Button>
+        <Button variant="subtle" onClick={reset}>
+          <RotateCcw className="h-4 w-4" /> Reset
+        </Button>
+        <Button variant="subtle" onClick={randomize}>
+          <Shuffle className="h-4 w-4" /> Random
+        </Button>
+      </ActionBar>
     </div>
   );
 }

--- a/src/components/PresetManager.jsx
+++ b/src/components/PresetManager.jsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { BookmarkPlus, Copy, Layers, Search, Trash2, X, Tag } from "lucide-react";
+import { Button, Input } from "./ui";
+
+const runtime = typeof window !== "undefined" ? window : null;
+
+const createId = () => {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const readPresets = (storageKey) => {
+  if (!runtime) return [];
+  try {
+    const raw = runtime.localStorage.getItem(storageKey);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn("Failed to parse presets", error);
+    return [];
+  }
+};
+
+const writePresets = (storageKey, presets) => {
+  if (!runtime) return;
+  try {
+    runtime.localStorage.setItem(storageKey, JSON.stringify(presets));
+  } catch (error) {
+    console.warn("Failed to persist presets", error);
+  }
+};
+
+const parseTags = (value) =>
+  value
+    .split(/[#;,\n]+/)
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+
+export default function PresetManager({
+  open,
+  onClose,
+  storageKey,
+  currentState,
+  onApply,
+  transformSave = (state) => state,
+  transformLoad = (state) => state,
+  title = "Presets",
+}) {
+  const [presets, setPresets] = useState(() => readPresets(storageKey));
+  const [search, setSearch] = useState("");
+  const [name, setName] = useState("");
+  const [tags, setTags] = useState("");
+
+  useEffect(() => {
+    setPresets(readPresets(storageKey));
+  }, [storageKey, open]);
+
+  useEffect(() => {
+    writePresets(storageKey, presets);
+  }, [presets, storageKey]);
+
+  const filtered = useMemo(() => {
+    const keyword = search.trim().toLowerCase();
+    if (!keyword) return presets;
+    return presets.filter((preset) => {
+      const haystack = `${preset.name} ${(preset.tags || []).join(" ")}`.toLowerCase();
+      return haystack.includes(keyword);
+    });
+  }, [presets, search]);
+
+  const handleSave = () => {
+    const nextName = name.trim() || `Preset ${presets.length + 1}`;
+    const nextTags = parseTags(tags);
+    const payload = transformSave(currentState);
+    const newPreset = {
+      id: createId(),
+      name: nextName,
+      tags: nextTags,
+      createdAt: Date.now(),
+      payload,
+    };
+    setPresets((prev) => [...prev, newPreset]);
+    setName("");
+    setTags("");
+  };
+
+  const handleApply = (preset) => {
+    onApply(transformLoad(preset.payload));
+    onClose();
+  };
+
+  const handleDuplicate = (preset) => {
+    const duplicate = {
+      ...preset,
+      id: createId(),
+      name: `${preset.name} copy`,
+      createdAt: Date.now(),
+    };
+    setPresets((prev) => [...prev, duplicate]);
+  };
+
+  const handleDelete = (id) => {
+    setPresets((prev) => prev.filter((preset) => preset.id !== id));
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-end justify-center sm:items-center bg-black/40 px-4 py-6">
+      <div className="w-full max-w-4xl bg-white rounded-3xl shadow-2xl border border-gray-200 overflow-hidden animate-in slide-in-from-bottom duration-200">
+        <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
+          <div className="flex items-center gap-2 text-gray-800 font-semibold">
+            <Layers className="h-5 w-5" />
+            {title}
+          </div>
+          <Button variant="ghost" onClick={onClose} title="Close presets">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4 max-h-[70vh] overflow-y-auto">
+          <div className="grid gap-3 sm:grid-cols-[2fr_1fr]">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-500">Name</label>
+                <Input value={name} onChange={setName} placeholder="e.g. Calm study shot" />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-gray-500 flex items-center gap-1">
+                  <Tag className="h-3.5 w-3.5" />Tags
+                </label>
+                <Input value={tags} onChange={setTags} placeholder="#portrait, candid" />
+              </div>
+            </div>
+            <div className="flex items-end justify-end">
+              <Button onClick={handleSave} className="w-full sm:w-auto" title="Save current settings as preset">
+                <BookmarkPlus className="h-4 w-4" />Save preset
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-xs font-medium text-gray-500 flex items-center gap-2">
+              <Search className="h-4 w-4" />Search presets
+            </label>
+            <Input value={search} onChange={setSearch} placeholder="Search by name or tag" />
+          </div>
+
+          <div className="space-y-3">
+            {filtered.length === 0 ? (
+              <div className="border border-dashed border-gray-300 rounded-2xl p-6 text-center text-sm text-gray-500">
+                No presets yet. Save your current setup to reuse later.
+              </div>
+            ) : (
+              filtered.map((preset) => (
+                <div
+                  key={preset.id}
+                  className="border border-gray-200 rounded-2xl px-4 py-3 flex flex-col gap-2 hover:border-black transition"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium text-gray-900">{preset.name}</div>
+                      {preset.tags?.length > 0 && (
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {preset.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full bg-gray-100 text-gray-600"
+                            >
+                              <Tag className="h-3 w-3" />{tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button variant="ghost" onClick={() => handleApply(preset)} title="Load preset">
+                        <Copy className="h-4 w-4" />Use
+                      </Button>
+                      <Button variant="ghost" onClick={() => handleDuplicate(preset)} title="Duplicate preset">
+                        <Layers className="h-4 w-4" />Duplicate
+                      </Button>
+                      <Button variant="ghost" onClick={() => handleDelete(preset.id)} title="Delete preset">
+                        <Trash2 className="h-4 w-4" />Delete
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="text-[11px] text-gray-400">
+                    Saved {new Date(preset.createdAt || Date.now()).toLocaleString()}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui.jsx
+++ b/src/components/ui.jsx
@@ -25,6 +25,7 @@ export const Button = ({
   variant = "default",
   title,
   type = "button",
+  disabled = false,
 }) => {
   const base =
     "inline-flex items-center gap-2 rounded-2xl px-3.5 py-2.5 text-sm font-medium transition border focus:outline-none";
@@ -37,8 +38,9 @@ export const Button = ({
     <button
       type={type}
       title={title}
+      disabled={disabled}
       onClick={onClick}
-      className={`${base} ${styles[variant]} ${className}`}
+      className={`${base} ${styles[variant]} ${disabled ? "opacity-60 cursor-not-allowed" : ""} ${className}`}
     >
       {children}
     </button>
@@ -106,13 +108,22 @@ export const Textarea = ({
   placeholder,
   rows = 4,
   className = "",
+  readOnly = false,
+  inputRef,
+  highlight = false,
+  highlightKey,
 }) => (
   <textarea
+    ref={inputRef}
     value={value}
     onChange={(e) => onChange(e.target.value)}
     placeholder={placeholder}
     rows={rows}
-    className={`w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm ${className}`}
+    readOnly={readOnly}
+    data-highlight-key={highlightKey}
+    className={`w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm ${
+      highlight ? "ring-2 ring-emerald-400 shadow-[0_0_0_3px_rgba(16,185,129,0.25)] animate-pulse" : ""
+    } ${className}`}
   />
 );
 
@@ -128,3 +139,19 @@ export const Toggle = ({ checked, onChange, label }) => (
   </label>
 );
 
+export const ActionBar = ({ children }) => (
+  <div className="fixed bottom-0 left-0 right-0 z-30 border-t border-gray-200 bg-white/90 backdrop-blur">
+    <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between gap-2 overflow-x-auto">
+      {children}
+    </div>
+  </div>
+);
+
+export const FloatingToast = ({ message }) => {
+  if (!message) return null;
+  return (
+    <div className="pointer-events-none fixed bottom-24 left-1/2 z-40 -translate-x-1/2 rounded-full bg-black px-4 py-2 text-xs font-medium text-white shadow-lg animate-in fade-in duration-150">
+      {message}
+    </div>
+  );
+};

--- a/src/data/animeOptions.js
+++ b/src/data/animeOptions.js
@@ -240,6 +240,30 @@ export const animeOptions = {
       jp: "アイドルアニメスタイル、光沢のあるハイライト、きらめく瞳、明るく鮮やかな色彩、磨かれたクリーンな線",
     },
   ],
+  cameraMovement: [
+    { en: "static anime cut", jp: "静止したアニメカット" },
+    { en: "slow pan across scene", jp: "ゆっくりパンして全景をなぞる" },
+    { en: "dramatic push-in", jp: "ドラマチックなプッシュイン" },
+    { en: "follow-through tracking", jp: "被写体を追うトラッキング" },
+    { en: "handheld wobble", jp: "手持ち風の揺れ" },
+  ],
+  shutterSpeed: [
+    { en: "1/48s (natural motion blur)", jp: "1/48秒（自然なモーションブラー）" },
+    { en: "1/60s (anime crisp)", jp: "1/60秒（アニメ的なキレ）" },
+    { en: "1/120s (sharp staccato)", jp: "1/120秒（シャープでスタッカート）" },
+  ],
+  colorGrade: [
+    { en: "neutral anime grade", jp: "ニュートラルなアニメ調グレーディング" },
+    { en: "pastel dream grade", jp: "パステルで夢見心地なグレーディング" },
+    { en: "neon city pop grade", jp: "ネオンのシティポップ調グレーディング" },
+    { en: "cinematic shadow grade", jp: "シネマ風の影を強調したグレーディング" },
+  ],
+  renderFinish: [
+    { en: "4K clean line art render", jp: "4Kのクリーンな線画レンダー" },
+    { en: "film grain overlay", jp: "フィルムグレインを重ねる" },
+    { en: "HDR anime composite", jp: "HDR対応のアニメ合成" },
+    { en: "cel shading preserved", jp: "セル塗りの質感を保持" },
+  ],
 };
 
 // Same as in options.js but for anime-specific groups.

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -180,15 +180,20 @@ export const options = {
     { en: "playing acoustic guitar", jp: "アコースティックギターを弾く" },
     { en: "painting on a canvas", jp: "キャンバスに絵を描く" },
     { en: "stretching arms lazily", jp: "腕を伸ばして伸びをする" },
+    { en: "closing a journal and exhaling", jp: "日記帳を閉じて息を吐く" },
+    { en: "turning pages slowly", jp: "ゆっくりページをめくる" },
+    { en: "glancing at the camera then looking away", jp: "カメラを一瞬見てから視線を外す" },
   ],
   shotDistance: [
     { en: "Extreme Long Shot (ELS)", jp: "エクストリームロングショット（人物がほとんど豆粒、背景中心）" },
     { en: "Long Shot (LS)", jp: "ロングショット（全身が収まる）" },
     { en: "Medium Long Shot (MLS)", jp: "ミディアムロングショット（膝から上）" },
     { en: "Medium Shot (MS)", jp: "ミディアムショット（腰から上）" },
+    { en: "Medium Wide Shot (MWS)", jp: "ミディアムワイドショット（膝下まで）" },
     { en: "Medium Close-up (MCU)", jp: "ミディアムクローズアップ（胸から上）" },
     { en: "Close-up (CU)", jp: "クローズアップ（顔や小物中心）" },
     { en: "Extreme Close-up (ECU)", jp: "エクストリームクローズアップ（目や口など細部のみ）" },
+    { en: "Wide Establishing Shot", jp: "ワイドな導入ショット" },
   ],
   shotAngle: [
     { en: "", jp: "" },
@@ -214,8 +219,32 @@ export const options = {
   cameraLens: [
     { en: "Fisheye (8mm)", jp: "フィッシュアイ(8mm)" },
     { en: "Wide-angle (24mm)", jp: "広角(24mm)" },
+    { en: "Wide standard (35mm)", jp: "準広角(35mm)" },
     { en: "Portrait (85mm)", jp: "ポートレート(85mm)" },
+    { en: "Telephoto portrait (105mm)", jp: "中望遠ポートレート(105mm)" },
     { en: "Telephoto (200mm)", jp: "望遠(200mm)" },
+  ],
+  cameraMovement: [
+    { en: "locked static frame", jp: "完全固定のフレーム" },
+    { en: "slow dolly-in toward subject", jp: "被写体へゆっくりドリーイン" },
+    { en: "subtle dolly-out revealing space", jp: "空間を見せる穏やかなドリーアウト" },
+    { en: "gentle left-to-right track", jp: "左から右への穏やかなトラック" },
+    { en: "slow pan following gaze", jp: "視線に合わせてゆっくりパン" },
+    { en: "elevating tilt up reveal", jp: "上方向へ見せるティルトアップ" },
+    { en: "handheld micro sway", jp: "ハンドヘルドの微かな揺れ" },
+  ],
+  shutterSpeed: [
+    { en: "1/48s (180° shutter, natural motion blur)", jp: "1/48秒（180°シャッターで自然なモーションブラー）" },
+    { en: "1/60s (slightly crisp motion)", jp: "1/60秒（ややシャープな動き）" },
+    { en: "1/96s (controlled staccato)", jp: "1/96秒（抑制されたスタッカート感）" },
+    { en: "1/120s (crisp freeze for details)", jp: "1/120秒（細部重視のシャープさ）" },
+  ],
+  colorGrade: [
+    { en: "neutral cinematic grade", jp: "ニュートラルなシネマ調グレーディング" },
+    { en: "warm Kodak-like grade", jp: "Kodak風の温かいグレーディング" },
+    { en: "cool teal-and-orange grade", jp: "ティール＆オレンジのクールなグレーディング" },
+    { en: "moody low-contrast grade", jp: "ローコントラストでムーディーなグレーディング" },
+    { en: "high-contrast noir grade", jp: "ハイコントラストのノワール調" },
   ],
   lighting: [
     { en: "soft desk lamp + ambient practicals", jp: "柔らかなデスクランプ＋室内の実用光" },
@@ -261,6 +290,13 @@ export const options = {
     { en: "Dark cinematic tones", jp: "ダークなシネマ調トーン" },
     { en: "Neon cyberpunk", jp: "ネオン・サイバーパンク" },
     { en: "Fashion-forward couture", jp: "最先端のクチュール" },
+  ],
+  renderFinish: [
+    { en: "deliver in 4K UHD, 24fps master", jp: "4K UHD・24fpsのマスターで仕上げ" },
+    { en: "graded for HDR10 delivery", jp: "HDR10仕上げ" },
+    { en: "clean prores-style export", jp: "ProRes風のクリーンな書き出し" },
+    { en: "film grain preserved, no heavy denoise", jp: "フィルムグレインを保持し強いノイズ除去はしない" },
+    { en: "sRGB safe output", jp: "sRGB準拠の出力" },
   ],
 };
 

--- a/src/hooks/useCopyFeedback.js
+++ b/src/hooks/useCopyFeedback.js
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const getRuntime = () => (typeof window !== "undefined" ? window : globalThis);
+
+export function useCopyFeedback(duration = 600) {
+  const [toast, setToast] = useState(null);
+  const [highlightKey, setHighlightKey] = useState(null);
+  const toastTimerRef = useRef(null);
+  const highlightTimerRef = useRef(null);
+
+  useEffect(() => {
+    const runtime = getRuntime();
+    return () => {
+      runtime.clearTimeout(toastTimerRef.current);
+      runtime.clearTimeout(highlightTimerRef.current);
+    };
+  }, []);
+
+  const showToast = useCallback(
+    (message) => {
+      const runtime = getRuntime();
+      runtime.clearTimeout(toastTimerRef.current);
+      setToast(message);
+      toastTimerRef.current = runtime.setTimeout(() => setToast(null), duration);
+    },
+    [duration]
+  );
+
+  const highlight = useCallback(
+    (key) => {
+      if (!key) return;
+      const runtime = getRuntime();
+      runtime.clearTimeout(highlightTimerRef.current);
+      setHighlightKey(key);
+      highlightTimerRef.current = runtime.setTimeout(() => setHighlightKey(null), duration);
+    },
+    [duration]
+  );
+
+  const copyWithFeedback = useCallback(
+    async (text, { element, label = "Copied", failLabel = "Copy failed" } = {}) => {
+      if (!text) {
+        showToast(failLabel);
+        return false;
+      }
+      if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+        showToast(failLabel);
+        return false;
+      }
+      try {
+        await navigator.clipboard.writeText(text);
+        if (typeof navigator.vibrate === "function") {
+          navigator.vibrate(35);
+        }
+        if (element?.current) {
+          const node = element.current;
+          node.focus?.();
+          if (typeof node.select === "function") {
+            node.select();
+            try {
+              node.setSelectionRange?.(0, text.length);
+            } catch (_) {
+              // Ignore selection range errors (e.g., for read-only nodes)
+            }
+          } else if (typeof window !== "undefined" && window.getSelection) {
+            const selection = window.getSelection();
+            const range = document.createRange();
+            range.selectNodeContents(node);
+            selection.removeAllRanges();
+            selection.addRange(range);
+          }
+          highlight(node.dataset.highlightKey || node.id || label);
+        } else {
+          highlight(label);
+        }
+        showToast(label);
+        return true;
+      } catch (error) {
+        console.error("Clipboard error", error);
+        showToast(failLabel);
+        return false;
+      }
+    },
+    [highlight, showToast]
+  );
+
+  return { toast, highlightKey, copyWithFeedback };
+}

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -1,0 +1,51 @@
+export function listToOxford(list = []) {
+  const filtered = list.filter(Boolean).map((item) => String(item).trim()).filter(Boolean);
+  if (filtered.length === 0) return "";
+  if (filtered.length === 1) return filtered[0];
+  if (filtered.length === 2) return `${filtered[0]} and ${filtered[1]}`;
+  return `${filtered.slice(0, -1).join(", ")}, and ${filtered[filtered.length - 1]}`;
+}
+
+export function ensureSentence(text) {
+  if (!text) return "";
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+export function normalizeEnglish(text) {
+  if (!text) return "";
+  let normalized = text
+    .replace(/[\s\u200B]+/g, " ")
+    .replace(/\s+,/g, ",")
+    .replace(/,\s*,/g, ", ")
+    .replace(/\s+\./g, ".")
+    .replace(/\s+;/g, ";")
+    .replace(/;\s*/g, "; ")
+    .replace(/\s+:/g, ":")
+    .replace(/:\s*/g, ": ")
+    .replace(/\s+!/g, "!")
+    .replace(/\s+\?/g, "?")
+    .replace(/\s+-\s+/g, "-")
+    .replace(/\(\s+/g, "(")
+    .replace(/\s+\)/g, ")")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  normalized = normalized.replace(/(^|[\s\(\[])[Aa] ([aeiouAEIOU])/g, "$1an $2");
+  normalized = normalized.replace(/(^|[\s\(\[])[Aa] ([Hh]onor|[Hh]our|[Hh]eir)/g, "$1an $2");
+  normalized = normalized.replace(/(^|[\s\(\[])[Aa]n ([^aeiouAEIOU])/g, "$1a $2");
+
+  normalized = normalized.replace(/\s*,\s*,/g, ", ");
+  normalized = normalized.replace(/,\s*\./g, ".");
+  normalized = normalized.replace(/\.(\s*\.)+/g, ".");
+
+  if (!/[.!?]$/.test(normalized)) {
+    normalized = `${normalized}.`;
+  }
+  return normalized;
+}
+
+export function compactSegments(segments = []) {
+  return segments.map((seg) => (seg || "").trim()).filter(Boolean);
+}


### PR DESCRIPTION
## Summary
- rebuild Sora and anime builders with slot-structured prompt generation, new film vocabulary controls, and auto English optimisation with copy feedback
- add reusable preset manager with local storage, search, tags, duplication, and bottom action bar for mobile-friendly copy/reset access
- introduce shared utilities for clipboard feedback, toast/highlight UI, and Oxford-comma formatting used in both builders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd706059f48322899bee8a705b3673